### PR TITLE
Update smartdns.init

### DIFF
--- a/contrib/openwrt/conf/smartdns.init
+++ b/contrib/openwrt/conf/smartdns.init
@@ -296,9 +296,10 @@ load_domain_rules()
 		conf_append "domain-rules" "/domain-set:${domain_set_name}-forwarding-file/ $domain_set_args"
 	}
 
+	conf_append "domain-set" "-name ${domain_set_name}-forwarding-list -file /etc/smartdns/domain-forwarding.list"
+
 	config_get domain_forwarding_list "$section" "domain_forwarding_list" ""
 	[ ! -z "$domain_forwarding_list" ] && {
-		conf_append "domain-set" "-name ${domain_set_name}-forwarding-list -file /etc/smartdns/domain-forwarding.list"
 		conf_append "domain-rules" "/domain-set:${domain_set_name}-forwarding-list/ $domain_set_args"
 	}
 


### PR DESCRIPTION
在域名规则列表为空或者无域名规则列表文件时，忽略执行域名规则列表。。。
域名分流文件存在，因此正常读取并执行。。。