### PR TITLE
smartdns.init：Add the judgment of domain name forwarding Settings

### DIFF
--- a/contrib/openwrt/conf/smartdns.init
+++ b/contrib/openwrt/conf/smartdns.init
@@ -296,8 +296,7 @@ load_domain_rules()
 		conf_append "domain-rules" "/domain-set:${domain_set_name}-forwarding-file/ $domain_set_args"
 	}
 
-	config_get domain_forwarding_list "$section" "domain_forwarding_list" ""
-	[ ! -z "$domain_forwarding_list" ] && {
+	[ ! -z "$domain_set_args" ] && {
 		conf_append "domain-set" "-name ${domain_set_name}-forwarding-list -file /etc/smartdns/domain-forwarding.list"
 		conf_append "domain-rules" "/domain-set:${domain_set_name}-forwarding-list/ $domain_set_args"
 	}


### PR DESCRIPTION
The luci screen automatically determines the commands for adding the domain name forwarding rule file based on whether the domain name forwarding rule is set to ensure that the software runs properly and the domain name forwarding rule is used properly.