### PR TITLE
Added docker configuration and pihole to smartdns converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Cargo.lock
 # web ui
 node_modules
 dist
+
+.idea/

--- a/contrib/docker/.gitignore
+++ b/contrib/docker/.gitignore
@@ -1,0 +1,3 @@
+smartdns.conf
+pihole.txt
+smartdns-ads.txt

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,44 @@
+ARG VERSION=0.6.1
+
+FROM debian:stable as downloader
+
+ARG VERSION
+
+RUN apt-get update && apt-get install -y curl
+RUN mkdir -p /app/x86 /app/arm64 /app/armv7 /app/extracted/x86 /app/extracted/arm64 /app/extracted/armv7
+
+
+RUN curl -L https://github.com/mokeyish/smartdns-rs/releases/download/$VERSION/smartdns-x86_64-unknown-linux-musl.tar.gz -o  /app/x86/smartdns.tar.gz
+RUN ls -lisa /app/x86
+RUN tar -xvf /app/x86/smartdns.tar.gz -C /app/extracted/x86
+
+RUN curl -L https://github.com/mokeyish/smartdns-rs/releases/download/$VERSION/smartdns-aarch64-unknown-linux-musl.tar.gz -o /app/arm64/smartdns.tar.gz
+
+RUN tar -xvf /app/arm64/smartdns.tar.gz -C /app/extracted/arm64
+RUN curl -L https://github.com/mokeyish/smartdns-rs/releases/download/$VERSION/smartdns-arm-unknown-linux-musleabihf.tar.gz -o /app/armv7/smartdns.tar.gz
+
+RUN tar -xvf /app/armv7/smartdns.tar.gz -C /app/extracted/armv7
+
+FROM alpine as base
+
+WORKDIR /app
+RUN apk add bash
+COPY docker-entrypoint.sh /app/entrypoint.sh
+FROM base as amd64
+
+COPY --from=downloader /app/extracted/x86/* /app/
+
+FROM base as armv7
+
+COPY --from=downloader /app/extracted/armv7/* /app/
+
+FROM base as arm64
+
+COPY --from=downloader /app/extracted/arm64/* /app/
+
+
+FROM ${TARGETARCH}${TARGETVARIANT} as final
+
+
+EXPOSE 8000
+CMD ["bash", "/app/entrypoint.sh"]

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  dns:
+    image: smartdns-rs
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+        - "53:53"
+        - "53:53/udp"
+    volumes:
+      - ./smartdns.conf:/app/smartdns.conf
+    #environment:
+      #- PARAMS= # Pass additional flags to the smartdns binary

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ ! -f /app/smartdns.conf ]]; then
+  echo "File /app/smartdns.conf is empty. It must be set in order to get started You can find additional information
+  here:"
+  echo "https://pymumu.github.io/smartdns/en/config/basic-config/"
+  exit 1
+fi
+
+# Init with default parameter
+if [[ -z "${PARAMS}" ]];then
+  PARAMS="run -c /app/smartdns.conf"
+fi
+/app/smartdns  $PARAMS

--- a/contrib/docker/pihole-to-smartdns.sh
+++ b/contrib/docker/pihole-to-smartdns.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Converts a pihole adlist like https://raw.githubusercontent.com/StevenBlack/hosts/master/data/StevenBlack/hosts to
+# a smartdns compatible format. Download the respective adlist and save it as pihole.txt in the same folder as this script.
+# Run this script and copy the content of the generated smartdns-ads.txt to your smartdns.conf file.
+
+output=''
+block_prefix="address /"
+block_suffix="/0.0.0.0"
+
+while read p; do
+
+  trimmed_output=$(echo $p| sed 's/^[ \t]*//;s/[ \t]*$//')
+  # If line is not a comment and not empty
+  if [[ $p != \#* && ! -z $trimmed_output ]]  ; then
+      output+=$block_prefix$(echo $trimmed_output | cut -d ' ' -f 2)$block_suffix
+  else
+      output+=$(echo $trimmed_output)
+  fi
+  output+='\n'
+done <pihole.txt
+
+echo -e $output > smartdns-ads.txt


### PR DESCRIPTION
- Adds a docker configuration to get started with smartdns-rs with Docker.
- Adds a pihole to smartdns converter

The first one solves the problem that I want to host smartdns not on a host and rather in docker-compose/K3S. It is configured by mapping a conf file into the container. This can be done in Kubernetes e.g. with a initContainer

As far as I can see there are only 2 "official" adlists for smartdns. This converter script enables the user to convert a pihole adlist which always has the format 0.0.0.0 address to address /address/# which does not resolve in smartdns. 
The output in smartdns-ads.txt can then be copied into your custom smartdns.conf file which then in return can be mounted into the Docker container.