### PR TITLE
Restart app upon receiving SIGHUP signal

### DIFF
--- a/src/dns_mw_cache.rs
+++ b/src/dns_mw_cache.rs
@@ -48,7 +48,7 @@ impl DnsCacheMiddleware {
                 if cache_file.exists() {
                     cache.lock().await.load(cache_file.as_path());
                 }
-                crate::signal::terminate()
+                let _ = crate::signal::terminate_or_restart_app()
                     .await
                     .expect("failed to wait ctrl_c for persist cache.");
                 cache.lock().await.persist(cache_file.as_path());


### PR DESCRIPTION
 Handle SIGHUP signal, and restart app upon receiving it.

 This allows reloading the app with updated configuration without
 restarting the process.