### PR TITLE
fix example config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ server https://1.1.1.1/dns-query  -bootstrap-dns -exclude-default-group
 server https://8.8.8.8/dns-query  -bootstrap-dns -exclude-default-group
 
 # Configure default upstream server
-server https://cloudflare-dns/dns-query
+server https://cloudflare-dns.com/dns-query
 server https://dns.quad9.net/dns-query
 server https://dns.google/dns-query
 


### PR DESCRIPTION
is there missing ".com" in the example config?


docs tell to use .com:
https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/
`https://cloudflare-dns.com/dns-query`

without it it I receive errors:
```
WARN:smartdns::dns_client:601: lookup ip: cloudflare-dns failed, proto error: no records found for Query { name: Name("cloudflare-dns."), query_type: AAAA, query_class: IN }
```
