### PR TITLE
✨ Add symlink subcommand and support for multiple query types

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,11 @@ pub struct Cli {
 
 impl Cli {
     pub fn parse() -> Self {
+        #[cfg(feature = "resolve-cli")]
+        if ResolveCommand::is_resolve_cli() {
+            return ResolveCommand::parse().into();
+        }
+
         match Self::try_parse() {
             Ok(cli) => cli,
             Err(e) => {
@@ -96,9 +101,16 @@ pub enum Commands {
         command: ServiceCommands,
     },
 
-    /// Perform DNS resolution. Can be used in place of the standard OS resolution facilities.
+    /// Perform DNS resolution.
     #[cfg(feature = "resolve-cli")]
     Resolve(ResolveCommand),
+
+    /// Create a symbolic link to the Smart-DNS binary (drop-in replacement for `dig`, `nslookup`, `resolve` etc.)
+    #[cfg(feature = "resolve-cli")]
+    Symlink {
+        /// The path to the symlink to create.
+        link: std::path::PathBuf,
+    },
 
     /// Test configuration and exit
     Test {

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,25 @@ impl Cli {
                 drop(_guard);
                 command.execute();
             }
+            #[cfg(all(feature = "resolve-cli", any(unix, windows)))]
+            Commands::Symlink { link } => {
+                let original = std::env::current_exe().expect("failed to get current exe path");
+                if link.exists() {
+                    println!("link already exists");
+                    return;
+                }
+
+                #[cfg(unix)]
+                let res = std::os::unix::fs::symlink(original, link);
+
+                #[cfg(windows)]
+                let res = std::os::windows::fs::symlink_file(original, link);
+
+                match res {
+                    Ok(()) => println!("symlink created"),
+                    Err(err) => println!("failed to create symlink, {}", err),
+                }
+            }
             #[allow(unreachable_patterns)]
             _ => {
                 unimplemented!()


### PR DESCRIPTION
1. Create smylink: `./smartdns symlink ./dig`

2. Query A and AAAA record: `./dig example.com a+aaaa`