### PR TITLE
✨ Implement tls-host-verify

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    net::{Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
     path::PathBuf,
     str::FromStr,
     sync::Arc,

--- a/src/config/parser/mod.rs
+++ b/src/config/parser/mod.rs
@@ -211,6 +211,7 @@ pub fn parse_config(input: &str) -> IResult<&str, OneConfig> {
         map(parse_item("domain"), OneConfig::Domain),
         map(parse_item("hosts-file"), OneConfig::HostsFile),
         map(parse_item("https-record"), OneConfig::HttpsRecord),
+        map(parse_item("ignore-ip"), OneConfig::IgnoreIp),
         map(parse_item("local-ttl"), OneConfig::LocalTtl),
         map(parse_item("log-console"), OneConfig::LogConsole),
         map(parse_item("log-file-mode"), OneConfig::LogFileMode),

--- a/src/config/parser/nameserver.rs
+++ b/src/config/parser/nameserver.rs
@@ -136,6 +136,24 @@ impl NomParser for NameServerInfo {
                     "k" | "no-check-certificate" => {
                         nameserver.server.set_ssl_verify(false);
                     }
+                    "tls-host-verify" => match v {
+                        Some(tls_host_verify) => match nameserver.server.host() {
+                            url::Host::Ipv4(ipv4_addr) => {
+                                nameserver.server.set_ip(IpAddr::V4(*ipv4_addr));
+                                nameserver.server.set_host(tls_host_verify);
+                            }
+                            url::Host::Ipv6(ipv6_addr) => {
+                                nameserver.server.set_ip(IpAddr::V6(*ipv6_addr));
+                                nameserver.server.set_host(tls_host_verify);
+                            }
+                            url::Host::Domain(_) => {
+                                log::warn!("tls-host-verify expects an ip address host");
+                            }
+                        },
+                        None => {
+                            log::warn!("expect tls-host-verify")
+                        }
+                    },
                     _ => {
                         log::warn!("unknown server options: {}, {:?}", k, v);
                     }

--- a/src/dns_client.rs
+++ b/src/dns_client.rs
@@ -502,7 +502,10 @@ impl NameServer {
             max_cocurrency: Arc::new(Semaphore::const_new(cocurrent.unwrap_or(1))),
             server: url.host().to_owned(),
             connections: Default::default(),
-            ip_addrs: Default::default(),
+            ip_addrs: url
+                .ip()
+                .map(|ip| RwLock::new(Arc::from([ip])))
+                .unwrap_or_default(),
             config,
             options: options.into(),
             connection_provider: provider,


### PR DESCRIPTION
This allows for connecting to secure servers without a bootstrap dns server.

Also exposes the `ignore-ip` config option which was seemingly accidentally omitted.