### PR TITLE
🎨 Send back original query on SOA

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -384,7 +384,7 @@ async fn process(
                                             response_header
                                                 .set_response_code(ResponseCode::NXDomain);
                                         }
-                                        match e.as_soa() {
+                                        match e.as_soa(request.query().original()) {
                                             Some(soa) => soa,
                                             None => {
                                                 log::debug!(

--- a/src/dns_error.rs
+++ b/src/dns_error.rs
@@ -57,16 +57,13 @@ impl LookupError {
         false
     }
 
-    pub fn as_soa(&self) -> Option<DnsResponse> {
+    pub fn as_soa(&self, query: &Query) -> Option<DnsResponse> {
         if let Self::Proto(err) = self {
             if let ProtoErrorKind::NoRecordsFound {
-                query,
-                soa: Some(record),
-                ..
+                soa: Some(record), ..
             } = err.kind()
             {
-                let mut dns_response =
-                    DnsResponse::new_with_max_ttl(query.as_ref().to_owned(), Vec::new());
+                let mut dns_response = DnsResponse::new_with_max_ttl(query.to_owned(), Vec::new());
                 dns_response.add_name_server(record.as_ref().to_owned().into_record_of_rdata());
                 return Some(dns_response);
             }


### PR DESCRIPTION
Needed for SOA responses to work when a `cname` rule changes the name