### PR TITLE
[WIP] Update smartdns.conf examples add bind-https

### DIFF
--- a/etc/smartdns/smartdns.conf
+++ b/etc/smartdns/smartdns.conf
@@ -18,6 +18,14 @@
 # conf-file blacklist-ip.conf
 
 # dns server bind ip and port, default dns server port is 53, support binding multi ip and port
+# bind https server
+#   bind-https [IP]:[port]
+#   bind-cert-key-file [path to file]
+#      https private key file
+#   bind-cert-file [path to file]
+#      https cert file
+#   bind-cert-key-pass [password]
+#      https private key password
 # bind udp server
 #   bind [IP]:[port][@device] [-group [group]] [-no-rule-addr] [-no-rule-nameserver] [-no-rule-ipset] [-no-speed-check] [-no-cache] [-no-rule-soa] [-no-dualstack-selection]
 # bind tcp server
@@ -46,10 +54,12 @@
 #    bind :53
 #    bind :53@eth0
 #    bind :6053 -group office -no-speed-check
+#    bind-https :8443
 #  IPV6:
 #    bind [::]:53
 #    bind [::]:53@eth0
 #    bind-tcp [::]:53
+#    bind-https [::]:8443
 bind [::]:53
 
 # tcp connection idle timeout


### PR DESCRIPTION
I just discovered the API + Swagger today and tried to get it working and found out how to at least get it to be served.

Very happy to se an API to be added, I was searching for something like it!
Would be great if in future it would be possible to add/update/delete zones / entries dynamically while running without a restart. 

As it currently seems to be missing from the config, I tried to add the examples in the config file, but I think it needs some more work.

For example should the bind-tls and bind-https always share the same cert or should it get a separate config entry like:

```
bind-https-cert-key-file
bind-https-cert-file
```

and then rename the old one for tls to:

```
bind-tls-cert-key-file
bind-tls-cert-file
```