### PR TITLE
🎨 Adjust privilege dropping behavior on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,9 +1759,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,7 +89,7 @@ pub enum Commands {
 
         /// Configuration directory, default to `/etc/smartdns``
         #[arg(short = 'd', long)]
-        direcory: Option<std::path::PathBuf>,
+        directory: Option<std::path::PathBuf>,
 
         /// Pid file
         #[arg(short = 'p', long)]
@@ -208,7 +208,7 @@ impl From<CompatibleCli> for Cli {
             command: Commands::Run {
                 conf,
                 pid,
-                direcory: None,
+                directory: None,
             },
             verbose: verbose0,
         }
@@ -249,7 +249,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 
@@ -259,7 +259,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
     }
@@ -287,7 +287,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 
@@ -324,7 +324,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 
@@ -334,7 +334,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
     }
@@ -347,7 +347,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 
@@ -359,7 +359,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
     }
@@ -372,7 +372,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 
@@ -387,7 +387,7 @@ mod tests {
             Commands::Run {
                 conf: Some(_),
                 pid: None,
-                direcory: None
+                directory: None
             }
         ));
 

--- a/src/service/linux/systemd/files/lib/systemd/system/smartdns-rs.service
+++ b/src/service/linux/systemd/files/lib/systemd/system/smartdns-rs.service
@@ -1,13 +1,14 @@
 [Unit]
 Description=SmartDNS Server
 After=network.target
+Before=network-online.target
+Before=nss-lookup.target
+Wants=nss-lookup.target
 StartLimitBurst=0
 StartLimitIntervalSec=60
 
 [Service]
 Type=simple
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
 PIDFile=/var/run/smartdns.pid
 ExecStart=/usr/sbin/smartdns run -p /var/run/smartdns.pid
 Restart=always


### PR DESCRIPTION
Modify the code to always drop privileges on Linux, regardless of whether
a user is configured or not. When no user is specifically set, fall back to using the 'nobody' user for privilege dropping.

This change enhances security by ensuring privilege reduction happens in all cases on Linux systems.