### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,9 @@ jobs:
     name: Build Docker image
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mokeyish/smartdns-rs/security/code-scanning/12](https://github.com/mokeyish/smartdns-rs/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the `Build Docker image` job. This block should explicitly define the minimal permissions required for the job. Based on the job's actions (e.g., logging into the GitHub Container Registry and pushing Docker images), the `contents: read` permission is sufficient for most steps, while `packages: write` is required for pushing Docker images.

The `permissions` block should be added directly under the `Build Docker image` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
