### PR TITLE
Support `server system`

### DIFF
--- a/src/config/nameserver.rs
+++ b/src/config/nameserver.rs
@@ -48,7 +48,7 @@ pub struct NameServerInfo {
     pub name: Option<String>,
 
     /// the nameserver url.
-    pub server: NameServerUrl,
+    pub server: DnsUrl,
 
     /// set server to group, use with nameserver /domain/group.
     /// ```
@@ -157,12 +157,6 @@ impl std::fmt::Display for NameServerInfo {
 
 impl From<DnsUrl> for NameServerInfo {
     fn from(url: DnsUrl) -> Self {
-        NameServerUrl::Url(url).into()
-    }
-}
-
-impl From<NameServerUrl> for NameServerInfo {
-    fn from(url: NameServerUrl) -> Self {
         Self {
             server: url,
             name: Default::default(),
@@ -178,33 +172,6 @@ impl From<NameServerUrl> for NameServerInfo {
             resolve_group: Default::default(),
             subnet: Default::default(),
             enabled: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum NameServerUrl {
-    System,
-    #[serde(untagged)]
-    Url(DnsUrl),
-}
-
-impl NameServerUrl {
-    pub fn url(&self) -> Option<&DnsUrl> {
-        if let Self::Url(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-}
-
-impl std::fmt::Display for NameServerUrl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NameServerUrl::System => write!(f, "system"),
-            NameServerUrl::Url(url) => url.fmt(f),
         }
     }
 }
@@ -260,24 +227,9 @@ mod tests {
         assert_eq!(name_server.name, Some("AliDNS".to_string()));
         assert_eq!(
             name_server.server,
-            NameServerUrl::Url("https://dns.alidns.com/dns-query".parse().unwrap())
+            "https://dns.alidns.com/dns-query".parse().unwrap()
         );
         assert_eq!(name_server.group, vec!["china".to_string()]);
         assert_eq!(name_server.enabled, Some(true));
-    }
-
-    #[test]
-    fn test_json_nameserver_url() {
-        for (nsurl, expect_json) in [
-            (
-                NameServerUrl::Url("https://dns.alidns.com/dns-query".parse().unwrap()),
-                r#""https://dns.alidns.com/dns-query""#,
-            ),
-            (NameServerUrl::System, r#""system""#),
-        ] {
-            let json = serde_json::to_string(&nsurl).unwrap();
-            assert_eq!(json, expect_json);
-            assert_eq!(serde_json::from_str::<NameServerUrl>(&json).unwrap(), nsurl);
-        }
     }
 }

--- a/src/config/nameserver.rs
+++ b/src/config/nameserver.rs
@@ -48,7 +48,7 @@ pub struct NameServerInfo {
     pub name: Option<String>,
 
     /// the nameserver url.
-    pub server: DnsUrl,
+    pub server: NameServerUrl,
 
     /// set server to group, use with nameserver /domain/group.
     /// ```
@@ -157,6 +157,12 @@ impl std::fmt::Display for NameServerInfo {
 
 impl From<DnsUrl> for NameServerInfo {
     fn from(url: DnsUrl) -> Self {
+        NameServerUrl::Url(url).into()
+    }
+}
+
+impl From<NameServerUrl> for NameServerInfo {
+    fn from(url: NameServerUrl) -> Self {
         Self {
             server: url,
             name: Default::default(),
@@ -172,6 +178,33 @@ impl From<DnsUrl> for NameServerInfo {
             resolve_group: Default::default(),
             subnet: Default::default(),
             enabled: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NameServerUrl {
+    System,
+    #[serde(untagged)]
+    Url(DnsUrl),
+}
+
+impl NameServerUrl {
+    pub fn url(&self) -> Option<&DnsUrl> {
+        if let Self::Url(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+impl std::fmt::Display for NameServerUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NameServerUrl::System => write!(f, "system"),
+            NameServerUrl::Url(url) => url.fmt(f),
         }
     }
 }
@@ -227,9 +260,24 @@ mod tests {
         assert_eq!(name_server.name, Some("AliDNS".to_string()));
         assert_eq!(
             name_server.server,
-            "https://dns.alidns.com/dns-query".parse().unwrap()
+            NameServerUrl::Url("https://dns.alidns.com/dns-query".parse().unwrap())
         );
         assert_eq!(name_server.group, vec!["china".to_string()]);
         assert_eq!(name_server.enabled, Some(true));
+    }
+
+    #[test]
+    fn test_json_nameserver_url() {
+        for (nsurl, expect_json) in [
+            (
+                NameServerUrl::Url("https://dns.alidns.com/dns-query".parse().unwrap()),
+                r#""https://dns.alidns.com/dns-query""#,
+            ),
+            (NameServerUrl::System, r#""system""#),
+        ] {
+            let json = serde_json::to_string(&nsurl).unwrap();
+            assert_eq!(json, expect_json);
+            assert_eq!(serde_json::from_str::<NameServerUrl>(&json).unwrap(), nsurl);
+        }
     }
 }

--- a/src/dns_client.rs
+++ b/src/dns_client.rs
@@ -12,6 +12,7 @@ use tokio::sync::RwLock;
 use url::Host;
 
 use crate::{
+    config::NameServerUrl,
     dns::DnsResponse,
     dns_conf::NameServerInfo,
     dns_error::LookupError,
@@ -102,16 +103,56 @@ impl DnsClientBuilder {
         } = self;
 
         let tls_client_config = TlsClientConfigBundle::new(ca_path, ca_file);
-        let mut default_group_servers = HashMap::new();
-        let mut server_instances = HashMap::new();
 
-        let bootstrap = async {
-            let mut bootstrap_servers = server_infos
+        let boot = Arc::new(BootstrapResolver::from_system_conf());
+
+        let mut server_instances = HashMap::<&NameServerInfo, _>::new();
+        let mut make_server = |server_config, resolver, dedup| {
+            let entry = server_instances.entry(server_config);
+            if let std::collections::hash_map::Entry::Occupied(_) = entry {
+                if dedup {
+                    return (None, &[][..]);
+                }
+            }
+            if let NameServerUrl::System = server_config.server {
+                entry.or_default();
+                return (None, &*boot.servers);
+            }
+            let server = entry.or_insert_with(|| {
+                let proxy = server_config
+                    .proxy
+                    .as_deref()
+                    .map(|n| proxies.get(n))
+                    .unwrap_or_default()
+                    .cloned();
+                match NameServer::new(
+                    server_config.clone(),
+                    proxy,
+                    Some(tls_client_config.clone()),
+                    resolver,
+                    client_subnet,
+                ) {
+                    Ok(s) => Some(Arc::new(s)),
+                    Err(err) => {
+                        let url = server_config.server.to_string();
+                        log::error!("failed to create nameserver {url}, error: {err}");
+                        None
+                    }
+                }
+            });
+            (server.clone(), &[][..])
+        };
+
+        let mut bootstrap_servers;
+        let bootstrap = {
+            bootstrap_servers = server_infos
                 .iter()
-                .filter(|info| {
-                    info.bootstrap_dns && {
-                        if info.server.ip().is_none() {
-                            warn!("bootstrap-dns must use ip addess, {:?}", info.server.host());
+                .filter(|info| info.bootstrap_dns)
+                .filter(|info| match &info.server {
+                    NameServerUrl::System => true,
+                    NameServerUrl::Url(server) => {
+                        if server.ip().is_none() {
+                            warn!("bootstrap-dns must use ip addess, {:?}", server.host());
                             false
                         } else {
                             true
@@ -124,15 +165,17 @@ impl DnsClientBuilder {
             if bootstrap_servers.is_empty() {
                 bootstrap_servers = server_infos
                     .iter()
-                    .filter(|info| info.server.ip().is_some() && info.proxy.is_none())
+                    .filter(|info| info.proxy.is_none())
+                    .filter(|info| match &info.server {
+                        NameServerUrl::System => true,
+                        NameServerUrl::Url(server) => server.ip().is_some(),
+                    })
                     .cloned()
                     .collect::<Vec<_>>()
             }
 
             if bootstrap_servers.is_empty() {
                 warn!("not bootstrap-dns found, use system_conf instead.");
-            } else {
-                bootstrap_servers.dedup();
             }
 
             if !bootstrap_servers.is_empty() {
@@ -141,47 +184,12 @@ impl DnsClientBuilder {
                 }
             }
 
-            let boot = Arc::new(BootstrapResolver::from_system_conf());
-
             let resolver: Arc<BootstrapResolver> = if !bootstrap_servers.is_empty() {
                 let servers = bootstrap_servers
-                    .into_iter()
+                    .iter()
                     .flat_map(|server_config| {
-                        let server = server_instances
-                            .entry(server_config.clone())
-                            .or_insert_with(|| {
-                                let proxy = server_config
-                                    .proxy
-                                    .as_deref()
-                                    .map(|n| proxies.get(n))
-                                    .unwrap_or_default()
-                                    .cloned();
-                                match NameServer::new(
-                                    server_config.clone(),
-                                    proxy,
-                                    Some(tls_client_config.clone()),
-                                    None,
-                                    client_subnet,
-                                ) {
-                                    Ok(s) => {
-                                        let s = Arc::new(s);
-                                        if !server_config.exclude_default_group {
-                                            default_group_servers.insert(server_config, s.clone());
-                                        }
-
-                                        Some(s)
-                                    }
-                                    Err(err) => {
-                                        let url = server_config.server.to_string();
-                                        log::error!(
-                                            "failed to create nameserver {url}, error: {err}"
-                                        );
-                                        None
-                                    }
-                                }
-                            });
-
-                        server.clone()
+                        let (server, servers) = make_server(&server_config, None, true);
+                        servers.iter().cloned().chain(server)
                     })
                     .collect();
 
@@ -192,88 +200,45 @@ impl DnsClientBuilder {
 
                 Arc::new(BootstrapResolver::new(new_resolver.into()))
             } else {
-                boot
+                boot.clone()
             };
 
             resolver
-        }
-        .await;
+        };
 
         assert!(!bootstrap.is_empty(), "no bootstrap nameserver found.");
 
-        let server_config_groups: HashMap<String, HashSet<NameServerInfo>> = server_infos
-            .iter()
-            .fold(HashMap::new(), |mut map, server_config| {
-                if server_config.group.is_empty() {
-                    map.entry("".to_string())
-                        .or_default()
-                        .insert(server_config.clone());
-                } else {
-                    for name in server_config.group.iter() {
-                        map.entry(name.to_string())
-                            .or_default()
-                            .insert(server_config.clone());
-                    }
-                }
-                map
-            });
+        let mut server_config_groups = HashMap::<Option<&str>, HashSet<&NameServerInfo>>::new();
+        for (g, server_config) in server_infos.iter().flat_map(|serv_conf| {
+            let group = serv_conf.group.iter().map(move |g| (Some(&**g), serv_conf));
+            let default = (!serv_conf.exclude_default_group).then_some((None, serv_conf));
+            group.chain(default)
+        }) {
+            server_config_groups
+                .entry(g)
+                .or_default()
+                .insert(server_config);
+        }
 
         let mut server_groups = HashMap::with_capacity(server_config_groups.len());
+        let mut default_group_servers = (*bootstrap).clone();
 
         let resolver_opts = Arc::new(bootstrap.options().clone());
 
-        for (group_name, group) in server_config_groups {
-            let server_configs = group.into_iter().collect::<Vec<_>>();
-
-            let mut servers = vec![];
-
-            for server_config in server_configs {
-                let server = server_instances
-                    .entry(server_config.clone())
-                    .or_insert_with(|| {
-                        let proxy = server_config
-                            .proxy
-                            .as_deref()
-                            .map(|n| proxies.get(n))
-                            .unwrap_or_default()
-                            .cloned();
-
-                        match NameServer::new(
-                            server_config.clone(),
-                            proxy,
-                            Some(tls_client_config.clone()),
-                            Some(bootstrap.clone()),
-                            client_subnet,
-                        ) {
-                            Ok(s) => {
-                                let s = Arc::new(s);
-                                if !server_config.exclude_default_group {
-                                    default_group_servers.insert(server_config, s.clone());
-                                }
-
-                                Some(s)
-                            }
-                            Err(err) => {
-                                let url = server_config.server.to_string();
-                                log::error!("failed to create nameserver {url}, error: {err}");
-                                None
-                            }
-                        }
-                    });
-
-                if let Some(s) = server {
-                    servers.push(s.clone());
-                }
-            }
+        for (group_name, group) in &server_config_groups {
+            let servers = group
+                .iter()
+                .flat_map(|server_config| {
+                    let (server, servers) =
+                        make_server(*server_config, Some(bootstrap.clone()), false);
+                    servers.iter().cloned().chain(server)
+                })
+                .collect();
 
             let server_group = NameServerGroup {
                 resolver_opts: resolver_opts.clone(),
                 servers,
             };
-
-            if group_name.is_empty() {
-                continue;
-            }
 
             debug!(
                 "create nameserver group {:?}, servers {}",
@@ -281,24 +246,19 @@ impl DnsClientBuilder {
                 server_group.len()
             );
 
-            server_groups.insert(group_name.clone(), Arc::new(server_group));
+            if let Some(group_name) = group_name {
+                server_groups.insert(group_name.to_string(), Arc::new(server_group));
+            } else {
+                default_group_servers = Arc::new(server_group);
+            }
         }
-
-        let default = if default_group_servers.is_empty() {
-            bootstrap.as_ref().deref().clone()
-        } else {
-            Arc::new(NameServerGroup {
-                resolver_opts,
-                servers: default_group_servers.into_values().collect(),
-            })
-        };
 
         for s in server_groups.values() {
             s.warmup().await;
         }
 
         DnsClient {
-            default,
+            default: default_group_servers,
             bootstrap,
             servers: server_groups,
         }
@@ -433,7 +393,9 @@ impl NameServer {
         resolver: Option<Arc<BootstrapResolver>>,
         default_client_subnet: Option<ClientSubnet>,
     ) -> anyhow::Result<Self> {
-        let url = &config.server;
+        let NameServerUrl::Url(url) = &config.server else {
+            unreachable!()
+        };
 
         let socket_addr = {
             let ip_addr = url.ip();


### PR DESCRIPTION
- #594 
- 允许nameserver的url为`system`
- 优化dns_client.rs代码：修复去重逻辑；用引用代替拷贝；让默认组与其他组一同处理

