### PR TITLE
Optional: Delete the managed folder when uninstalling the service

### DIFF
--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -47,7 +47,7 @@ async fn create(
     let Some(managed_dir) = cfg.managed_dir() else {
         return Err(ApiError::NotFound("managed_dir not found".to_string()));
     };
-    if managed_dir.exists() {
+    if !managed_dir.exists() {
         std::fs::create_dir_all(managed_dir)?;
     }
     let file = managed_dir.join("address.conf");

--- a/src/service/linux/initd/mod.rs
+++ b/src/service/linux/initd/mod.rs
@@ -26,6 +26,10 @@ pub fn create_service_definition() -> ServiceDefinition {
         .add_item((CONF_DIR, RemoveIfEmpty))
         .add_item((CONF_PATH, crate::DEFAULT_CONF, 0o644, Preserve, Keep))
         .add_item((service_file_path, service_file, 0o755))
+        .add_item((
+            std::path::PathBuf::from(CONF_DIR).join("managed"),
+            RemoveIfEmpty,
+        ))
         .build();
 
     let service_ctl = "service";

--- a/src/service/linux/systemd/mod.rs
+++ b/src/service/linux/systemd/mod.rs
@@ -17,6 +17,10 @@ pub fn create_service_definition() -> ServiceDefinition {
         .add_item((CONF_DIR, RemoveIfEmpty))
         .add_item((CONF_PATH, crate::DEFAULT_CONF, 0o644, Preserve, Keep))
         .add_item((SERVICE_FILE_PATH, SERVICE_FILE, 0o644))
+        .add_item((
+            std::path::PathBuf::from(CONF_DIR).join("managed"),
+            RemoveIfEmpty,
+        ))
         .build();
 
     let service_name: &str = &[SERVICE_NAME, ".service"].concat();

--- a/src/service/macos/launchctl.rs
+++ b/src/service/macos/launchctl.rs
@@ -20,6 +20,10 @@ pub fn create_service_definition() -> ServiceDefinition {
         .add_item((CONF_DIR, RemoveIfEmpty))
         .add_item((CONF_PATH, crate::DEFAULT_CONF, 0o644, Preserve, Keep))
         .add_item((SERVICE_FILE_PATH, SERVICE_FILE, 0o644))
+        .add_item((
+            std::path::PathBuf::from(CONF_DIR).join("managed"),
+            RemoveIfEmpty,
+        ))
         .build();
 
     let launch_ctl = "launchctl";

--- a/src/service/windows/mod.rs
+++ b/src/service/windows/mod.rs
@@ -26,6 +26,10 @@ pub(super) fn create_service_definition() -> ServiceDefinition {
         .install_current_exe_to(BIN_PATH)
         .add_item((CONF_DIR, RemoveIfEmpty))
         .add_item((CONF_PATH, crate::DEFAULT_CONF, Preserve, Keep))
+        .add_item((
+            std::path::PathBuf::from(CONF_DIR).join("managed"),
+            RemoveIfEmpty,
+        ))
         .build();
 
     let mut bin_path = OsString::new();


### PR DESCRIPTION
I'm not sure if this was the original intention, so this is a separate pull request.

And there is a small typo fix located at https://github.com/mokeyish/smartdns-rs/blob/656d1d46f5d4baaf9c58d79b28b3149a2689fa3b/src/api/address.rs#L50
It is assumed that the folder should only be created if it does not already exist.