### PR TITLE
Fix record name mismatch when speedtest is enabled with CNAME

### DIFF
--- a/src/dns_mw_ns.rs
+++ b/src/dns_mw_ns.rs
@@ -448,11 +448,14 @@ async fn lookup_ip(
 
     if let Some(selected_ip) = selected_ip {
         for mut res in ok_tasks {
-            let record = res
+            if let Some(mut record) = res
                 .take_answers()
                 .into_iter()
-                .find(|r| matches!(r.data().ip_addr(), Some(ip) if ip == selected_ip));
-            if let Some(record) = record {
+                .find(|r| matches!(r.data().ip_addr(), Some(ip) if ip == selected_ip))
+            {
+                if record.name() != &name {
+                    record.set_name(name.clone());
+                }
                 res.add_answer(record);
                 return Ok(res);
             }


### PR DESCRIPTION
Now, when retrieving A/AAAA records from the cache (which typically include speed test results for CNAME domains),will check whether the record domain matches the requested domain. If they do not match, the record is replaced with the requested domain.
This should fix problem of https://github.com/mokeyish/smartdns-rs/issues/676