### PR TITLE
fix saving address.conf if file not exists

### DIFF
--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -83,7 +83,8 @@ async fn create(
 
         std::fs::write(&file, format!("{config}"))?;
     } else {
-        std::fs::write(&file, format!("{rule}"))?;
+        let config = ConfigItem::Address(rule);
+        std::fs::write(&file, format!("{config}"))?;
     }
 
     Ok(StatusCode::CREATED)


### PR DESCRIPTION
If file did not exist, it would not write a fully config file before.

Now the question is, how to load it into running config afterwards ...