### PR TITLE
Optimization: Reuse ICMP clients to reduce resource consumption, increased concurrent limit for background tasks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -249,7 +249,7 @@ pub fn serve(cfg: Arc<RuntimeConfig>) {
 
             const BATCH_SIZE: usize = 256;
 
-            let background_concurrency = Arc::new(Semaphore::new(1));
+            let background_concurrency = Arc::new(Semaphore::new(16));
             let mut bg_batch = FuturesUnordered::new();
             let mut requests = Vec::with_capacity(BATCH_SIZE);
 

--- a/src/service/installer.rs
+++ b/src/service/installer.rs
@@ -345,18 +345,13 @@ impl Default for InstallStrategy {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum UninstallStrategy {
     Keep,
+    #[default]
     Remove,
     /// If directory is empty, remove it.
     RemoveIfEmpty,
-}
-
-impl Default for UninstallStrategy {
-    fn default() -> Self {
-        Self::Remove
-    }
 }
 
 impl Installer {


### PR DESCRIPTION
1. Modify src/infra/ping.rs to use a global singleton or Arc-shared surge_ping::Client. This can significantly reduce socket operations and the number of background coroutines.
2. Increased the concurrent limit for background tasks. Since prefetch also needs to use the background task pool. This will significantly improve the speed of initial requests domain's speedtesting with large caches.