### PR TITLE
feat(zone): canonicalize CHAOS TXT identity query names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3219,7 @@ dependencies = [
  "ipnet",
  "local-ip-address",
  "lru",
+ "mac-addr",
  "netdev",
  "nom 8.0.0",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ boomphf = { version = "0.6.0", optional = true }
 local-ip-address = "0.6.1"
 console = { version = "0.15.8", optional = true }
 rangemap = "1.5.1"
+mac-addr = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 uzers = { version = "0.12", default-features = false }

--- a/README.md
+++ b/README.md
@@ -180,12 +180,8 @@ dig @127.0.0.1 CH TXT smartdns +short
 # SmartDNS native short name (without `.bind`)
 dig @127.0.0.1 CH TXT version +short
 
-# SmartDNS native JSON and multi-record aliases
+# SmartDNS native JSON alias
 dig @127.0.0.1 CH TXT json.smartdns +short
-dig @127.0.0.1 CH TXT records.smartdns +short
-
-# compatibility alias
-dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
 ```
 
 `whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).

--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ server-quic unfiltered.adguard-dns.com
 
 For more advanced configurations, please refer to [here](https://github.com/pymumu/smartdns/blob/doc/en/docs/configuration.md) , and refer to [TODO](https://github.com/mokeyish/smartdns-rs/blob/main/TODO.md) for the function coverage.
 
+## Built-in diagnostics via `dig`
+
+SmartDNS-rs supports built-in `CHAOS TXT` queries for server/client diagnostics.
+
+```shell
+# server hostname
+dig @127.0.0.1 CH TXT hostname.bind +short
+
+# server version
+dig @127.0.0.1 CH TXT version.bind +short
+
+# client source IP seen by smartdns-rs
+dig @127.0.0.1 CH TXT whoami.bind +short
+
+# client MAC from ARP table (LAN, ARP available)
+dig @127.0.0.1 CH TXT whoami.mac.bind +short
+
+# combined output
+dig @127.0.0.1 CH TXT smartdns.info.bind +short
+```
+
+`whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).
+
 ## Building
 
 Assuming you have installed [Rust](https://www.rust-lang.org/learn/get-started), then you can open the terminal and execute these commands:

--- a/README.md
+++ b/README.md
@@ -159,11 +159,14 @@ SmartDNS-rs supports built-in `CHAOS TXT` queries for server/client diagnostics.
 # most common: full identity info (multi TXT records)
 dig @127.0.0.1 CH TXT whoami +short
 
+# full identity info (multi TXT records, alias)
+dig @127.0.0.1 CH TXT smartdns +short
+
 # server name
 dig @127.0.0.1 CH TXT server-name +short
 
 # server version
-dig @127.0.0.1 CH TXT version.bind +short
+dig @127.0.0.1 CH TXT version +short
 
 # client source IP seen by smartdns-rs
 dig @127.0.0.1 CH TXT client-ip +short
@@ -171,23 +174,12 @@ dig @127.0.0.1 CH TXT client-ip +short
 # client MAC from ARP table (LAN, ARP available)
 dig @127.0.0.1 CH TXT client-mac +short
 
-# combined output
-dig @127.0.0.1 CH TXT smartdns.info.bind +short
-
 # JSON output (single TXT record)
-dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
-
-# multiple TXT records (default overview, one key-value per record)
-dig @127.0.0.1 CH TXT smartdns +short
-
-# SmartDNS native short name (without `.bind`)
-dig @127.0.0.1 CH TXT version +short
-
-# SmartDNS native JSON alias
 dig @127.0.0.1 CH TXT json.smartdns +short
 
 # BIND compatibility examples
 dig @127.0.0.1 CH TXT hostname.bind +short
+dig @127.0.0.1 CH TXT version.bind +short
 dig @127.0.0.1 CH TXT whoami.bind +short
 dig @127.0.0.1 CH TXT whoami.mac.bind +short
 ```

--- a/README.md
+++ b/README.md
@@ -156,17 +156,20 @@ For more advanced configurations, please refer to [here](https://github.com/pymu
 SmartDNS-rs supports built-in `CHAOS TXT` queries for server/client diagnostics.
 
 ```shell
-# server hostname
-dig @127.0.0.1 CH TXT hostname.bind +short
+# most common: full identity info (multi TXT records)
+dig @127.0.0.1 CH TXT whoami +short
+
+# server name
+dig @127.0.0.1 CH TXT server-name +short
 
 # server version
 dig @127.0.0.1 CH TXT version.bind +short
 
 # client source IP seen by smartdns-rs
-dig @127.0.0.1 CH TXT whoami.bind +short
+dig @127.0.0.1 CH TXT client-ip +short
 
 # client MAC from ARP table (LAN, ARP available)
-dig @127.0.0.1 CH TXT whoami.mac.bind +short
+dig @127.0.0.1 CH TXT client-mac +short
 
 # combined output
 dig @127.0.0.1 CH TXT smartdns.info.bind +short
@@ -182,6 +185,11 @@ dig @127.0.0.1 CH TXT version +short
 
 # SmartDNS native JSON alias
 dig @127.0.0.1 CH TXT json.smartdns +short
+
+# BIND compatibility examples
+dig @127.0.0.1 CH TXT hostname.bind +short
+dig @127.0.0.1 CH TXT whoami.bind +short
+dig @127.0.0.1 CH TXT whoami.mac.bind +short
 ```
 
 `whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).

--- a/README.md
+++ b/README.md
@@ -180,15 +180,11 @@ dig @127.0.0.1 CH TXT client-mac +short
 dig @127.0.0.1 CH TXT whoami.json +short
 dig @127.0.0.1 CH TXT smartdns.json +short
 
-# BIND compatibility examples
+# Compatibility examples
 dig @127.0.0.1 CH TXT hostname.bind +short
 dig @127.0.0.1 CH TXT version.bind +short
-dig @127.0.0.1 CH TXT whoami.bind +short
-dig @127.0.0.1 CH TXT whoami.mac.bind +short
 dig @127.0.0.1 CH TXT id.server +short
 ```
-
-`whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ dig @127.0.0.1 CH TXT smartdns.info.bind +short
 # JSON output (single TXT record)
 dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
 
-# multiple TXT records (one key-value per record)
-dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
+# multiple TXT records (default overview, one key-value per record)
+dig @127.0.0.1 CH TXT smartdns +short
 
 # SmartDNS native short name (without `.bind`)
 dig @127.0.0.1 CH TXT version +short
@@ -183,6 +183,9 @@ dig @127.0.0.1 CH TXT version +short
 # SmartDNS native JSON and multi-record aliases
 dig @127.0.0.1 CH TXT json.smartdns +short
 dig @127.0.0.1 CH TXT records.smartdns +short
+
+# compatibility alias
+dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
 ```
 
 `whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ dig @127.0.0.1 CH TXT whoami.mac.bind +short
 
 # combined output
 dig @127.0.0.1 CH TXT smartdns.info.bind +short
+
+# JSON output (single TXT record)
+dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
+
+# multiple TXT records (one key-value per record)
+dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
+
+# SmartDNS native short name (without `.bind`)
+dig @127.0.0.1 CH TXT version +short
+
+# SmartDNS native JSON and multi-record aliases
+dig @127.0.0.1 CH TXT json.smartdns +short
+dig @127.0.0.1 CH TXT records.smartdns +short
 ```
 
 `whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ For more advanced configurations, please refer to [here](https://github.com/pymu
 SmartDNS-rs supports built-in `CHAOS TXT` queries for server/client diagnostics.
 
 ```shell
-# most common: full identity info (multi TXT records)
+# most common: full identity info (server + client, multi TXT records)
 dig @127.0.0.1 CH TXT whoami +short
 
-# full identity info (multi TXT records, alias)
+# server identity info only (multi TXT records)
 dig @127.0.0.1 CH TXT smartdns +short
 
 # server name
@@ -169,19 +169,21 @@ dig @127.0.0.1 CH TXT server-name +short
 dig @127.0.0.1 CH TXT version +short
 
 # client source IP seen by smartdns-rs
-dig @127.0.0.1 CH TXT client-ip +short
+dig @127.0.0.1 CH TXT ip.whoami +short
 
 # client MAC from ARP table (LAN, ARP available)
-dig @127.0.0.1 CH TXT client-mac +short
+dig @127.0.0.1 CH TXT mac.whoami +short
 
-# JSON output (single TXT record)
-dig @127.0.0.1 CH TXT json.smartdns +short
+# JSON output with suffix style
+dig @127.0.0.1 CH TXT whoami.json +short
+dig @127.0.0.1 CH TXT smartdns.json +short
 
 # BIND compatibility examples
 dig @127.0.0.1 CH TXT hostname.bind +short
 dig @127.0.0.1 CH TXT version.bind +short
 dig @127.0.0.1 CH TXT whoami.bind +short
 dig @127.0.0.1 CH TXT whoami.mac.bind +short
+dig @127.0.0.1 CH TXT id.server +short
 ```
 
 `whoami.mac.bind` depends on ARP visibility from the server host (typically same L2 network on Linux).

--- a/README.md
+++ b/README.md
@@ -169,10 +169,12 @@ dig @127.0.0.1 CH TXT server-name +short
 dig @127.0.0.1 CH TXT version +short
 
 # client source IP seen by smartdns-rs
-dig @127.0.0.1 CH TXT ip.whoami +short
+dig @127.0.0.1 CH TXT client_ip +short
+dig @127.0.0.1 CH TXT client-ip +short
 
 # client MAC from ARP table (LAN, ARP available)
-dig @127.0.0.1 CH TXT mac.whoami +short
+dig @127.0.0.1 CH TXT client_mac +short
+dig @127.0.0.1 CH TXT client-mac +short
 
 # JSON output with suffix style
 dig @127.0.0.1 CH TXT whoami.json +short

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -179,12 +179,8 @@ dig @127.0.0.1 CH TXT smartdns +short
 # SmartDNS 自有短名称（去掉 `.bind`）
 dig @127.0.0.1 CH TXT version +short
 
-# SmartDNS 自有 JSON / 多记录别名
+# SmartDNS 自有 JSON 别名
 dig @127.0.0.1 CH TXT json.smartdns +short
-dig @127.0.0.1 CH TXT records.smartdns +short
-
-# 兼容别名
-dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
 ```
 
 `whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -158,11 +158,14 @@ SmartDNS-rs 支持通过 `CHAOS TXT` 查询内置诊断字段。
 # 最常用：一次返回完整身份信息（多条 TXT）
 dig @127.0.0.1 CH TXT whoami +short
 
+# 完整身份信息（多条 TXT，别名）
+dig @127.0.0.1 CH TXT smartdns +short
+
 # 服务器名
 dig @127.0.0.1 CH TXT server-name +short
 
 # 服务器版本
-dig @127.0.0.1 CH TXT version.bind +short
+dig @127.0.0.1 CH TXT version +short
 
 # 服务端看到的客户端源 IP
 dig @127.0.0.1 CH TXT client-ip +short
@@ -170,23 +173,12 @@ dig @127.0.0.1 CH TXT client-ip +short
 # 客户端 MAC（局域网且服务端 ARP 表可见）
 dig @127.0.0.1 CH TXT client-mac +short
 
-# 聚合信息
-dig @127.0.0.1 CH TXT smartdns.info.bind +short
-
 # JSON 输出（单条 TXT）
-dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
-
-# 多条 TXT 输出（默认总览入口，每条一个键值）
-dig @127.0.0.1 CH TXT smartdns +short
-
-# SmartDNS 自有短名称（去掉 `.bind`）
-dig @127.0.0.1 CH TXT version +short
-
-# SmartDNS 自有 JSON 别名
 dig @127.0.0.1 CH TXT json.smartdns +short
 
 # BIND 兼容示例
 dig @127.0.0.1 CH TXT hostname.bind +short
+dig @127.0.0.1 CH TXT version.bind +short
 dig @127.0.0.1 CH TXT whoami.bind +short
 dig @127.0.0.1 CH TXT whoami.mac.bind +short
 ```

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -169,6 +169,19 @@ dig @127.0.0.1 CH TXT whoami.mac.bind +short
 
 # 聚合信息
 dig @127.0.0.1 CH TXT smartdns.info.bind +short
+
+# JSON 输出（单条 TXT）
+dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
+
+# 多条 TXT 输出（每条一个键值）
+dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
+
+# SmartDNS 自有短名称（去掉 `.bind`）
+dig @127.0.0.1 CH TXT version +short
+
+# SmartDNS 自有 JSON / 多记录别名
+dig @127.0.0.1 CH TXT json.smartdns +short
+dig @127.0.0.1 CH TXT records.smartdns +short
 ```
 
 `whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -150,6 +150,29 @@ server-quic 223.5.5.5
 
 更多高级的配置请参考 [这里](https://github.com/pymumu/smartdns/blob/doc/docs/configuration.md)
 
+## 使用 `dig` 查询内置诊断信息
+
+SmartDNS-rs 支持通过 `CHAOS TXT` 查询内置诊断字段。
+
+```shell
+# 服务器名
+dig @127.0.0.1 CH TXT hostname.bind +short
+
+# 服务器版本
+dig @127.0.0.1 CH TXT version.bind +short
+
+# 服务端看到的客户端源 IP
+dig @127.0.0.1 CH TXT whoami.bind +short
+
+# 客户端 MAC（局域网且服务端 ARP 表可见）
+dig @127.0.0.1 CH TXT whoami.mac.bind +short
+
+# 聚合信息
+dig @127.0.0.1 CH TXT smartdns.info.bind +short
+```
+
+`whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。
+
 ## 从源码构建与运行
 
 假设你已经安装了 [Rust](https://www.rust-lang.org/learn/get-started)，那么你可以打开命令行界面，执行如下命令：

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -155,10 +155,10 @@ server-quic 223.5.5.5
 SmartDNS-rs 支持通过 `CHAOS TXT` 查询内置诊断字段。
 
 ```shell
-# 最常用：一次返回完整身份信息（多条 TXT）
+# 最常用：一次返回完整身份信息（服务端+客户端，多条 TXT）
 dig @127.0.0.1 CH TXT whoami +short
 
-# 完整身份信息（多条 TXT，别名）
+# 仅服务端身份信息（多条 TXT）
 dig @127.0.0.1 CH TXT smartdns +short
 
 # 服务器名
@@ -168,19 +168,21 @@ dig @127.0.0.1 CH TXT server-name +short
 dig @127.0.0.1 CH TXT version +short
 
 # 服务端看到的客户端源 IP
-dig @127.0.0.1 CH TXT client-ip +short
+dig @127.0.0.1 CH TXT ip.whoami +short
 
 # 客户端 MAC（局域网且服务端 ARP 表可见）
-dig @127.0.0.1 CH TXT client-mac +short
+dig @127.0.0.1 CH TXT mac.whoami +short
 
-# JSON 输出（单条 TXT）
-dig @127.0.0.1 CH TXT json.smartdns +short
+# JSON 输出（后缀风格）
+dig @127.0.0.1 CH TXT whoami.json +short
+dig @127.0.0.1 CH TXT smartdns.json +short
 
 # BIND 兼容示例
 dig @127.0.0.1 CH TXT hostname.bind +short
 dig @127.0.0.1 CH TXT version.bind +short
 dig @127.0.0.1 CH TXT whoami.bind +short
 dig @127.0.0.1 CH TXT whoami.mac.bind +short
+dig @127.0.0.1 CH TXT id.server +short
 ```
 
 `whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -168,10 +168,12 @@ dig @127.0.0.1 CH TXT server-name +short
 dig @127.0.0.1 CH TXT version +short
 
 # 服务端看到的客户端源 IP
-dig @127.0.0.1 CH TXT ip.whoami +short
+dig @127.0.0.1 CH TXT client_ip +short
+dig @127.0.0.1 CH TXT client-ip +short
 
 # 客户端 MAC（局域网且服务端 ARP 表可见）
-dig @127.0.0.1 CH TXT mac.whoami +short
+dig @127.0.0.1 CH TXT client_mac +short
+dig @127.0.0.1 CH TXT client-mac +short
 
 # JSON 输出（后缀风格）
 dig @127.0.0.1 CH TXT whoami.json +short

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -155,17 +155,20 @@ server-quic 223.5.5.5
 SmartDNS-rs 支持通过 `CHAOS TXT` 查询内置诊断字段。
 
 ```shell
+# 最常用：一次返回完整身份信息（多条 TXT）
+dig @127.0.0.1 CH TXT whoami +short
+
 # 服务器名
-dig @127.0.0.1 CH TXT hostname.bind +short
+dig @127.0.0.1 CH TXT server-name +short
 
 # 服务器版本
 dig @127.0.0.1 CH TXT version.bind +short
 
 # 服务端看到的客户端源 IP
-dig @127.0.0.1 CH TXT whoami.bind +short
+dig @127.0.0.1 CH TXT client-ip +short
 
 # 客户端 MAC（局域网且服务端 ARP 表可见）
-dig @127.0.0.1 CH TXT whoami.mac.bind +short
+dig @127.0.0.1 CH TXT client-mac +short
 
 # 聚合信息
 dig @127.0.0.1 CH TXT smartdns.info.bind +short
@@ -181,6 +184,11 @@ dig @127.0.0.1 CH TXT version +short
 
 # SmartDNS 自有 JSON 别名
 dig @127.0.0.1 CH TXT json.smartdns +short
+
+# BIND 兼容示例
+dig @127.0.0.1 CH TXT hostname.bind +short
+dig @127.0.0.1 CH TXT whoami.bind +short
+dig @127.0.0.1 CH TXT whoami.mac.bind +short
 ```
 
 `whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -173,8 +173,8 @@ dig @127.0.0.1 CH TXT smartdns.info.bind +short
 # JSON 输出（单条 TXT）
 dig @127.0.0.1 CH TXT smartdns.info.json.bind +short
 
-# 多条 TXT 输出（每条一个键值）
-dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
+# 多条 TXT 输出（默认总览入口，每条一个键值）
+dig @127.0.0.1 CH TXT smartdns +short
 
 # SmartDNS 自有短名称（去掉 `.bind`）
 dig @127.0.0.1 CH TXT version +short
@@ -182,6 +182,9 @@ dig @127.0.0.1 CH TXT version +short
 # SmartDNS 自有 JSON / 多记录别名
 dig @127.0.0.1 CH TXT json.smartdns +short
 dig @127.0.0.1 CH TXT records.smartdns +short
+
+# 兼容别名
+dig @127.0.0.1 CH TXT smartdns.info.records.bind +short
 ```
 
 `whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -179,15 +179,11 @@ dig @127.0.0.1 CH TXT client-mac +short
 dig @127.0.0.1 CH TXT whoami.json +short
 dig @127.0.0.1 CH TXT smartdns.json +short
 
-# BIND 兼容示例
+# 兼容性示例
 dig @127.0.0.1 CH TXT hostname.bind +short
 dig @127.0.0.1 CH TXT version.bind +short
-dig @127.0.0.1 CH TXT whoami.bind +short
-dig @127.0.0.1 CH TXT whoami.mac.bind +short
 dig @127.0.0.1 CH TXT id.server +short
 ```
-
-`whoami.mac.bind` 依赖服务端主机对客户端的 ARP 可见性（通常要求同二层网络，Linux 下可用）。
 
 ## 从源码构建与运行
 

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -176,27 +176,70 @@ impl DnsZoneMiddleware {
         let query_name = normalize_query_name(query.name());
         let client_ip = normalize_client_ip(req.src().ip());
         let server_name = trim_fqdn_dot(ctx.cfg().server_name().to_string());
-
-        let value = match query_name.as_str() {
-            "hostname.bind." | "id.server." => server_name.clone(),
-            "version.bind." => crate::BUILD_VERSION.to_string(),
-            "whoami.bind." | "client.ip.bind." | "clientip.bind." => client_ip.to_string(),
-            "whoami.mac.bind." | "client.mac.bind." | "clientmac.bind." => {
-                lookup_client_mac_from_arp(client_ip)
-                    .unwrap_or_else(|| UNKNOWN_CLIENT_MAC.to_string())
-            }
-            "smartdns.info.bind." => {
-                let client_mac = lookup_client_mac_from_arp(client_ip)
-                    .unwrap_or_else(|| UNKNOWN_CLIENT_MAC.to_string());
-                format!(
-                    "server_name={server_name};server_version={};client_ip={client_ip};client_mac={client_mac}",
-                    crate::BUILD_VERSION,
-                )
-            }
-            _ => return None,
+        let client_mac = || {
+            lookup_client_mac_from_arp(client_ip).unwrap_or_else(|| UNKNOWN_CLIENT_MAC.to_string())
         };
 
-        Some(txt_response(query, value))
+        match query_name.as_str() {
+            // BIND compatibility
+            "hostname.bind." | "id.server." => Some(txt_response(query, server_name.clone())),
+            "version.bind." => Some(txt_response(query, crate::BUILD_VERSION.to_string())),
+            "whoami.bind." | "client.ip.bind." | "clientip.bind." => {
+                Some(txt_response(query, client_ip.to_string()))
+            }
+            "whoami.mac.bind." | "client.mac.bind." | "clientmac.bind." => {
+                Some(txt_response(query, client_mac()))
+            }
+            "smartdns.info.bind." => Some(txt_response(
+                query,
+                build_info_kv_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+            )),
+            "smartdns.info.json.bind." => Some(txt_response(
+                query,
+                build_info_json_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+            )),
+            "smartdns.info.records.bind." => Some(txt_records_response(
+                query,
+                build_info_records_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+
+            // SmartDNS native names (without `.bind`)
+            "hostname.smartdns." | "server-name.smartdns." | "hostname." => {
+                Some(txt_response(query, server_name.clone()))
+            }
+            "version.smartdns." | "server-version.smartdns." | "version." => {
+                Some(txt_response(query, crate::BUILD_VERSION.to_string()))
+            }
+            "whoami.smartdns." | "client-ip.smartdns." | "clientip.smartdns." | "whoami." => {
+                Some(txt_response(query, client_ip.to_string()))
+            }
+            "whoami-mac.smartdns." | "client-mac.smartdns." | "clientmac.smartdns." => {
+                Some(txt_response(query, client_mac()))
+            }
+            "info.smartdns." => Some(txt_response(
+                query,
+                build_info_kv_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+            )),
+            "json.smartdns." | "info.json.smartdns." => Some(txt_response(
+                query,
+                build_info_json_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+            )),
+            "records.smartdns." | "info.records.smartdns." => Some(txt_records_response(
+                query,
+                build_info_records_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            _ => None,
+        }
     }
 }
 
@@ -225,6 +268,57 @@ fn txt_response(query: Query, value: String) -> DnsResponse {
     );
     record.set_dns_class(query.query_class());
     DnsResponse::new_with_max_ttl(query, vec![record])
+}
+
+fn txt_records_response(query: Query, values: Vec<String>) -> DnsResponse {
+    let records = values
+        .into_iter()
+        .map(|value| {
+            let mut record = Record::from_rdata(
+                query.name().to_owned(),
+                crate::dns_client::MAX_TTL,
+                RData::TXT(TXT::new(vec![value])),
+            );
+            record.set_dns_class(query.query_class());
+            record
+        })
+        .collect::<Vec<_>>();
+
+    DnsResponse::new_with_max_ttl(query, records)
+}
+
+fn build_info_kv_text(server_name: &str, version: &str, client_ip: &IpAddr, client_mac: &str) -> String {
+    format!(
+        "server_name={server_name};server_version={version};client_ip={client_ip};client_mac={client_mac}",
+    )
+}
+
+fn build_info_records_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> Vec<String> {
+    vec![
+        format!("server_name={server_name}"),
+        format!("server_version={version}"),
+        format!("client_ip={client_ip}"),
+        format!("client_mac={client_mac}"),
+    ]
+}
+
+fn build_info_json_text(server_name: &str, version: &str, client_ip: &IpAddr, client_mac: &str) -> String {
+    let server_name = json_escape(server_name);
+    let version = json_escape(version);
+    let client_ip = json_escape(&client_ip.to_string());
+    let client_mac = json_escape(client_mac);
+    format!(
+        r#"{{"server_name":"{server_name}","server_version":"{version}","client_ip":"{client_ip}","client_mac":"{client_mac}"}}"#
+    )
+}
+
+fn json_escape(value: &str) -> String {
+    value.chars().flat_map(|c| c.escape_default()).collect()
 }
 
 #[cfg(test)]
@@ -371,6 +465,81 @@ mod tests {
                 .data()
                 .to_string()
                 .contains(UNKNOWN_CLIENT_MAC)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_builtin_txt_json_query() {
+        let cfg = RuntimeConfig::builder()
+            .with("server-name smartdns-rs-test")
+            .build()
+            .unwrap();
+        let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
+
+        let response = search_with_query(
+            &mock,
+            "json.smartdns",
+            RecordType::TXT,
+            DNSClass::CH,
+            "192.168.1.10:5300".parse().unwrap(),
+        )
+        .await;
+
+        let out = response.answers()[0].data().to_string();
+        assert!(out.contains("\"server_name\""));
+        assert!(out.contains("\"server_version\""));
+        assert!(out.contains("\"client_ip\""));
+        assert!(out.contains("192.168.1.10"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_builtin_txt_multi_records_query() {
+        let cfg = RuntimeConfig::builder()
+            .with("server-name smartdns-rs-test")
+            .build()
+            .unwrap();
+        let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
+
+        let response = search_with_query(
+            &mock,
+            "records.smartdns",
+            RecordType::TXT,
+            DNSClass::CH,
+            "192.168.1.11:5300".parse().unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.answers().len(), 4);
+        let txts = response
+            .answers()
+            .iter()
+            .map(|record| record.data().to_string())
+            .collect::<Vec<_>>();
+        assert!(txts.iter().any(|txt| txt.contains("server_name=")));
+        assert!(txts.iter().any(|txt| txt.contains("server_version=")));
+        assert!(txts.iter().any(|txt| txt.contains("client_ip=")));
+        assert!(txts.iter().any(|txt| txt.contains("client_mac=")));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_builtin_txt_short_name_version_alias() {
+        let cfg = RuntimeConfig::builder().build().unwrap();
+        let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
+
+        let response = search_with_query(
+            &mock,
+            "version",
+            RecordType::TXT,
+            DNSClass::CH,
+            "192.168.1.12:5300".parse().unwrap(),
+        )
+        .await;
+
+        assert!(
+            response.answers()[0]
+                .data()
+                .to_string()
+                .contains(crate::BUILD_VERSION)
         );
     }
 }

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -148,7 +148,12 @@ mod tests {
         )
         .await;
 
-        assert!(response.answers()[0].data().to_string().contains("smartdns-rs-test"));
+        assert!(
+            response.answers()[0]
+                .data()
+                .to_string()
+                .contains("smartdns-rs-test")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -552,7 +552,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[tokio::test(flavor = "multi_thread")]
     async fn test_builtin_txt_short_name_version_alias() {
         let cfg = RuntimeConfig::builder().build().unwrap();
         let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -340,7 +340,12 @@ mod tests {
             "127.0.0.1:5300".parse().unwrap(),
         )
         .await;
-        assert!(mac_response2.answers()[0].data().to_string().contains("N/A"));
+        assert!(
+            mac_response2.answers()[0]
+                .data()
+                .to_string()
+                .contains("N/A")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -429,4 +429,19 @@ mod tests {
             assert!(matches!(res, Err(ref err) if err.is_soa()));
         }
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_identity_txt_in_class_is_not_intercepted() {
+        let cfg = RuntimeConfig::builder().build().unwrap();
+        let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
+
+        let mut query = Query::query("version".parse().unwrap(), RecordType::TXT);
+        query.set_query_class(DNSClass::IN);
+        let mut message = op::Message::query();
+        message.add_query(query);
+        let req = DnsRequest::new(message, "192.168.1.14:5300".parse().unwrap(), Protocol::Udp);
+
+        let res = mock.search(&req, &Default::default()).await;
+        assert!(matches!(res, Err(ref err) if err.is_soa()));
+    }
 }

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use crate::libdns::proto::op::Query;
@@ -9,7 +9,7 @@ use crate::libdns::proto::rr::rdata::{PTR, TXT};
 
 use crate::config::HttpsRecordRule;
 use crate::dns::*;
-use crate::infra::ipset::IpSet;
+use crate::infra::{arp::lookup_client_mac_from_arp, ipset::IpSet};
 use crate::middleware::*;
 
 const UNKNOWN_CLIENT_MAC: &str = "N/A";
@@ -227,120 +227,6 @@ fn txt_response(query: Query, value: String) -> DnsResponse {
     DnsResponse::new_with_max_ttl(query, vec![record])
 }
 
-fn parse_arp_table_mac(table: &str, target_ip: Ipv4Addr) -> Option<String> {
-    let target_ip = target_ip.to_string();
-    table.lines().skip(1).find_map(|line| {
-        let mut fields = line.split_whitespace();
-        let ip = fields.next()?;
-        let _hardware_type = fields.next()?;
-        let _flags = fields.next()?;
-        let mac = fields.next()?;
-
-        if ip != target_ip {
-            return None;
-        }
-
-        if mac == "00:00:00:00:00:00" {
-            return None;
-        }
-
-        Some(mac.to_ascii_lowercase())
-    })
-}
-
-fn normalize_mac_token(token: &str) -> Option<String> {
-    let token = token.trim_matches(|c: char| matches!(c, '(' | ')' | '[' | ']' | ','));
-    let normalized = token.replace('-', ":").to_ascii_lowercase();
-
-    if normalized == "00:00:00:00:00:00" {
-        return None;
-    }
-
-    let parts = normalized.split(':').collect::<Vec<_>>();
-    if parts.len() != 6 {
-        return None;
-    }
-
-    if !parts
-        .iter()
-        .all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit()))
-    {
-        return None;
-    }
-
-    Some(normalized)
-}
-
-fn parse_arp_command_output_mac(output: &str, target_ip: Ipv4Addr) -> Option<String> {
-    let target_ip = target_ip.to_string();
-    output.lines().find_map(|line| {
-        if !line.contains(&target_ip) {
-            return None;
-        }
-        line.split_whitespace().find_map(normalize_mac_token)
-    })
-}
-
-fn client_ipv4_for_arp(client_ip: IpAddr) -> Option<Ipv4Addr> {
-    match client_ip {
-        IpAddr::V4(ip) if !ip.is_loopback() => Some(ip),
-        _ => None,
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn run_arp_command(args: &[&str]) -> Option<String> {
-    let output = std::process::Command::new("arp").args(args).output().ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    Some(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn lookup_mac_from_arp_command_output(client_ip: Ipv4Addr, args: &[&str]) -> Option<String> {
-    run_arp_command(args).and_then(|output| parse_arp_command_output_mac(&output, client_ip))
-}
-
-#[cfg(target_os = "linux")]
-fn lookup_client_mac_from_arp(client_ip: IpAddr) -> Option<String> {
-    let client_ip = client_ipv4_for_arp(client_ip)?;
-
-    std::fs::read_to_string("/proc/net/arp")
-        .ok()
-        .and_then(|table| parse_arp_table_mac(&table, client_ip))
-}
-
-#[cfg(all(not(target_os = "linux"), target_os = "windows"))]
-fn lookup_client_mac_from_arp_command(client_ip: Ipv4Addr) -> Option<String> {
-    let ip = client_ip.to_string();
-    lookup_mac_from_arp_command_output(client_ip, &["-a", ip.as_str()])
-}
-
-#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
-fn lookup_client_mac_from_arp_command(client_ip: Ipv4Addr) -> Option<String> {
-    let ip = client_ip.to_string();
-    for args in [
-        ["-n", ip.as_str()],
-        ["-an", ip.as_str()],
-        ["-a", ip.as_str()],
-    ] {
-        if let Some(mac) = lookup_mac_from_arp_command_output(client_ip, &args) {
-            return Some(mac);
-        }
-    }
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-fn lookup_client_mac_from_arp(client_ip: IpAddr) -> Option<String> {
-    let client_ip = client_ipv4_for_arp(client_ip)?;
-
-    lookup_client_mac_from_arp_command(client_ip)
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -485,46 +371,6 @@ mod tests {
                 .data()
                 .to_string()
                 .contains(UNKNOWN_CLIENT_MAC)
-        );
-    }
-
-    #[test]
-    fn test_parse_arp_table_mac() {
-        let table = "IP address       HW type     Flags       HW address            Mask     Device\n\
-                     192.168.1.10     0x1         0x2         aa:bb:cc:dd:ee:ff     *        eth0\n\
-                     192.168.1.11     0x1         0x2         00:00:00:00:00:00     *        eth0";
-
-        assert_eq!(
-            parse_arp_table_mac(table, "192.168.1.10".parse().unwrap()),
-            Some("aa:bb:cc:dd:ee:ff".to_string())
-        );
-        assert_eq!(
-            parse_arp_table_mac(table, "192.168.1.11".parse().unwrap()),
-            None
-        );
-        assert_eq!(
-            parse_arp_table_mac(table, "192.168.1.12".parse().unwrap()),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_arp_command_output_mac_unix() {
-        let output = "? (192.168.1.10) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]";
-        assert_eq!(
-            parse_arp_command_output_mac(output, "192.168.1.10".parse().unwrap()),
-            Some("aa:bb:cc:dd:ee:ff".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_arp_command_output_mac_windows() {
-        let output = "Interface: 192.168.1.1 --- 0x7\n\
-                      Internet Address      Physical Address      Type\n\
-                      192.168.1.10          aa-bb-cc-dd-ee-ff     dynamic";
-        assert_eq!(
-            parse_arp_command_output_mac(output, "192.168.1.10".parse().unwrap()),
-            Some("aa:bb:cc:dd:ee:ff".to_string())
         );
     }
 }

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -4,8 +4,8 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
 use crate::libdns::proto::op::Query;
-use crate::libdns::proto::rr::rdata::{PTR, TXT};
 use crate::libdns::proto::rr::DNSClass;
+use crate::libdns::proto::rr::rdata::{PTR, TXT};
 
 use crate::config::HttpsRecordRule;
 use crate::dns::*;
@@ -382,7 +382,12 @@ mod tests {
             "192.168.1.9:5300".parse().unwrap(),
         )
         .await;
-        assert!(ip_response.answers()[0].data().to_string().contains("192.168.1.9"));
+        assert!(
+            ip_response.answers()[0]
+                .data()
+                .to_string()
+                .contains("192.168.1.9")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -397,7 +402,12 @@ mod tests {
             "127.0.0.1:5300".parse().unwrap(),
         )
         .await;
-        assert!(response.answers()[0].data().to_string().contains(UNKNOWN_CLIENT_MAC));
+        assert!(
+            response.answers()[0]
+                .data()
+                .to_string()
+                .contains(UNKNOWN_CLIENT_MAC)
+        );
     }
 
     #[test]

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -288,13 +288,13 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_builtin_txt_whoami_fields_query() {
+    async fn test_builtin_txt_client_fields_query() {
         let cfg = RuntimeConfig::builder().build().unwrap();
         let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
 
         let ip_response = search_with_query(
             &mock,
-            "ip.whoami",
+            "client_ip",
             RecordType::TXT,
             DNSClass::CH,
             "192.168.1.13:5300".parse().unwrap(),
@@ -309,13 +309,38 @@ mod tests {
 
         let mac_response = search_with_query(
             &mock,
-            "mac.whoami",
+            "client_mac",
             RecordType::TXT,
             DNSClass::CH,
             "127.0.0.1:5300".parse().unwrap(),
         )
         .await;
         assert!(mac_response.answers()[0].data().to_string().contains("N/A"));
+
+        let ip_response2 = search_with_query(
+            &mock,
+            "client-ip",
+            RecordType::TXT,
+            DNSClass::CH,
+            "192.168.1.13:5300".parse().unwrap(),
+        )
+        .await;
+        assert!(
+            ip_response2.answers()[0]
+                .data()
+                .to_string()
+                .contains("192.168.1.13")
+        );
+
+        let mac_response2 = search_with_query(
+            &mock,
+            "client-mac",
+            RecordType::TXT,
+            DNSClass::CH,
+            "127.0.0.1:5300".parse().unwrap(),
+        )
+        .await;
+        assert!(mac_response2.answers()[0].data().to_string().contains("N/A"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -2,9 +2,6 @@ use crate::dns::*;
 use crate::middleware::*;
 use crate::zone::{IdentityZoneProvider, LocalPtrZoneProvider, RuleZoneProvider, ZoneManager};
 
-#[cfg(test)]
-use crate::libdns::proto::op::Query;
-
 pub struct DnsZoneMiddleware {
     manager: ZoneManager,
     rule_provider: RuleZoneProvider,
@@ -46,6 +43,7 @@ mod tests {
 
     use super::*;
     use crate::infra::ipset::IpSet;
+    use crate::libdns::proto::op::Query;
     use crate::libdns::proto::rr::DNSClass;
     use crate::{dns_conf::RuntimeConfig, dns_mw::*};
     use std::net::SocketAddr;

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -201,11 +201,9 @@ impl DnsZoneMiddleware {
 }
 
 fn normalize_query_name(name: &Name) -> String {
-    let mut name = name.to_string().to_ascii_lowercase();
-    if !name.ends_with('.') {
-        name.push('.');
-    }
-    name
+    let mut normalized = name.clone();
+    normalized.set_fqdn(true);
+    normalized.to_string().to_ascii_lowercase()
 }
 
 fn trim_fqdn_dot(name: String) -> String {

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -240,12 +240,7 @@ mod tests {
             "127.0.0.1:5300".parse().unwrap(),
         )
         .await;
-        assert!(
-            response.answers()[0]
-                .data()
-                .to_string()
-                .contains("N/A")
-        );
+        assert!(response.answers()[0].data().to_string().contains("N/A"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -201,7 +201,11 @@ impl DnsZoneMiddleware {
 }
 
 fn normalize_query_name(name: &Name) -> String {
-    name.to_string().to_ascii_lowercase()
+    let mut name = name.to_string().to_ascii_lowercase();
+    if !name.ends_with('.') {
+        name.push('.');
+    }
+    name
 }
 
 fn trim_fqdn_dot(name: String) -> String {

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -283,10 +283,7 @@ fn parse_arp_command_output_mac(output: &str, target_ip: Ipv4Addr) -> Option<Str
 
 #[cfg(not(target_os = "linux"))]
 fn run_arp_command(args: &[&str]) -> Option<String> {
-    let output = std::process::Command::new("arp")
-        .args(args)
-        .output()
-        .ok()?;
+    let output = std::process::Command::new("arp").args(args).output().ok()?;
 
     if !output.status.success() {
         return None;
@@ -326,7 +323,11 @@ fn lookup_client_mac_from_arp(client_ip: IpAddr) -> Option<String> {
     }
 
     #[cfg(not(target_os = "windows"))]
-    for args in [["-n", ip.as_str()], ["-an", ip.as_str()], ["-a", ip.as_str()]] {
+    for args in [
+        ["-n", ip.as_str()],
+        ["-an", ip.as_str()],
+        ["-a", ip.as_str()],
+    ] {
         if let Some(output) = run_arp_command(&args)
             && let Some(mac) = parse_arp_command_output_mac(&output, client_ip)
         {

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -192,11 +192,21 @@ impl DnsZoneMiddleware {
             }
             "smartdns.info.bind." => Some(txt_response(
                 query,
-                build_info_kv_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+                build_info_kv_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
             )),
             "smartdns.info.json.bind." => Some(txt_response(
                 query,
-                build_info_json_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+                build_info_json_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
             )),
             "smartdns.info.records.bind." => Some(txt_records_response(
                 query,
@@ -223,11 +233,21 @@ impl DnsZoneMiddleware {
             }
             "info.smartdns." => Some(txt_response(
                 query,
-                build_info_kv_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+                build_info_kv_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
             )),
             "json.smartdns." | "info.json.smartdns." => Some(txt_response(
                 query,
-                build_info_json_text(&server_name, crate::BUILD_VERSION, &client_ip, &client_mac()),
+                build_info_json_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
             )),
             "records.smartdns." | "info.records.smartdns." => Some(txt_records_response(
                 query,
@@ -287,7 +307,12 @@ fn txt_records_response(query: Query, values: Vec<String>) -> DnsResponse {
     DnsResponse::new_with_max_ttl(query, records)
 }
 
-fn build_info_kv_text(server_name: &str, version: &str, client_ip: &IpAddr, client_mac: &str) -> String {
+fn build_info_kv_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> String {
     format!(
         "server_name={server_name};server_version={version};client_ip={client_ip};client_mac={client_mac}",
     )
@@ -307,7 +332,12 @@ fn build_info_records_text(
     ]
 }
 
-fn build_info_json_text(server_name: &str, version: &str, client_ip: &IpAddr, client_mac: &str) -> String {
+fn build_info_json_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> String {
     let server_name = json_escape(server_name);
     let version = json_escape(version);
     let client_ip = json_escape(&client_ip.to_string());

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -300,7 +300,12 @@ mod tests {
             "192.168.1.13:5300".parse().unwrap(),
         )
         .await;
-        assert!(ip_response.answers()[0].data().to_string().contains("192.168.1.13"));
+        assert!(
+            ip_response.answers()[0]
+                .data()
+                .to_string()
+                .contains("192.168.1.13")
+        );
 
         let mac_response = search_with_query(
             &mock,
@@ -336,7 +341,10 @@ mod tests {
             .iter()
             .map(|record| record.data().to_string())
             .collect::<Vec<_>>();
-        assert!(txts.iter().any(|txt| txt.contains("server_name=smartdns-rs-test")));
+        assert!(
+            txts.iter()
+                .any(|txt| txt.contains("server_name=smartdns-rs-test"))
+        );
         assert!(txts.iter().any(|txt| txt.contains("server_version=")));
     }
 

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -322,7 +322,11 @@ fn lookup_client_mac_from_arp_command(client_ip: Ipv4Addr) -> Option<String> {
 #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
 fn lookup_client_mac_from_arp_command(client_ip: Ipv4Addr) -> Option<String> {
     let ip = client_ip.to_string();
-    for args in [["-n", ip.as_str()], ["-an", ip.as_str()], ["-a", ip.as_str()]] {
+    for args in [
+        ["-n", ip.as_str()],
+        ["-an", ip.as_str()],
+        ["-a", ip.as_str()],
+    ] {
         if let Some(mac) = lookup_mac_from_arp_command_output(client_ip, &args) {
             return Some(mac);
         }

--- a/src/dns_mw_zone.rs
+++ b/src/dns_mw_zone.rs
@@ -208,7 +208,7 @@ impl DnsZoneMiddleware {
                     &client_mac(),
                 ),
             )),
-            "smartdns.bind." | "smartdns.info.records.bind." => Some(txt_records_response(
+            "smartdns.bind." => Some(txt_records_response(
                 query,
                 build_info_records_text(
                     &server_name,
@@ -249,17 +249,15 @@ impl DnsZoneMiddleware {
                     &client_mac(),
                 ),
             )),
-            "smartdns." | "records.smartdns." | "info.records.smartdns." => {
-                Some(txt_records_response(
-                    query,
-                    build_info_records_text(
-                        &server_name,
-                        crate::BUILD_VERSION,
-                        &client_ip,
-                        &client_mac(),
-                    ),
-                ))
-            }
+            "smartdns." => Some(txt_records_response(
+                query,
+                build_info_records_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
             _ => None,
         }
     }
@@ -554,25 +552,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_builtin_txt_multi_records_alias_query() {
-        let cfg = RuntimeConfig::builder()
-            .with("server-name smartdns-rs-test")
-            .build()
-            .unwrap();
-        let mock = DnsMockMiddleware::mock(DnsZoneMiddleware::new()).build(cfg);
-
-        let response = search_with_query(
-            &mock,
-            "records.smartdns",
-            RecordType::TXT,
-            DNSClass::CH,
-            "192.168.1.11:5300".parse().unwrap(),
-        )
-        .await;
-
-        assert_eq!(response.answers().len(), 4);
-    }
-
     #[tokio::test(flavor = "multi_thread")]
     async fn test_builtin_txt_short_name_version_alias() {
         let cfg = RuntimeConfig::builder().build().unwrap();

--- a/src/infra/arp.rs
+++ b/src/infra/arp.rs
@@ -1,0 +1,165 @@
+use std::net::{IpAddr, Ipv4Addr};
+
+pub fn lookup_client_mac_from_arp(client_ip: IpAddr) -> Option<String> {
+    client_ipv4_for_arp(client_ip).and_then(lookup_client_mac_from_arp_v4)
+}
+
+fn client_ipv4_for_arp(client_ip: IpAddr) -> Option<Ipv4Addr> {
+    match client_ip {
+        IpAddr::V4(ip) if !ip.is_loopback() => Some(ip),
+        _ => None,
+    }
+}
+
+fn parse_arp_table_mac(table: &str, target_ip: Ipv4Addr) -> Option<String> {
+    let target_ip = target_ip.to_string();
+    table.lines().skip(1).find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let ip = fields.next()?;
+        let _hardware_type = fields.next()?;
+        let _flags = fields.next()?;
+        let mac = fields.next()?;
+
+        if ip != target_ip {
+            return None;
+        }
+
+        if mac == "00:00:00:00:00:00" {
+            return None;
+        }
+
+        Some(mac.to_ascii_lowercase())
+    })
+}
+
+fn normalize_mac_token(token: &str) -> Option<String> {
+    let token = token.trim_matches(|c: char| matches!(c, '(' | ')' | '[' | ']' | ','));
+    let normalized = token.replace('-', ":").to_ascii_lowercase();
+
+    if normalized == "00:00:00:00:00:00" {
+        return None;
+    }
+
+    let parts = normalized.split(':').collect::<Vec<_>>();
+    if parts.len() != 6 {
+        return None;
+    }
+
+    if !parts
+        .iter()
+        .all(|part| part.len() == 2 && part.chars().all(|c| c.is_ascii_hexdigit()))
+    {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn parse_arp_command_output_mac(output: &str, target_ip: Ipv4Addr) -> Option<String> {
+    let target_ip = target_ip.to_string();
+    output.lines().find_map(|line| {
+        if !line.contains(&target_ip) {
+            return None;
+        }
+        line.split_whitespace().find_map(normalize_mac_token)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn lookup_client_mac_from_arp_v4(client_ip: Ipv4Addr) -> Option<String> {
+    std::fs::read_to_string("/proc/net/arp")
+        .ok()
+        .and_then(|table| parse_arp_table_mac(&table, client_ip))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_arp_command(args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("arp").args(args).output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn lookup_mac_from_arp_command_output(client_ip: Ipv4Addr, args: &[&str]) -> Option<String> {
+    run_arp_command(args).and_then(|output| parse_arp_command_output_mac(&output, client_ip))
+}
+
+#[cfg(all(not(target_os = "linux"), target_os = "windows"))]
+fn lookup_client_mac_from_arp_v4(client_ip: Ipv4Addr) -> Option<String> {
+    let ip = client_ip.to_string();
+    lookup_mac_from_arp_command_output(client_ip, &["-a", ip.as_str()])
+}
+
+#[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
+fn lookup_client_mac_from_arp_v4(client_ip: Ipv4Addr) -> Option<String> {
+    let ip = client_ip.to_string();
+    for args in [
+        ["-n", ip.as_str()],
+        ["-an", ip.as_str()],
+        ["-a", ip.as_str()],
+    ] {
+        if let Some(mac) = lookup_mac_from_arp_command_output(client_ip, &args) {
+            return Some(mac);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_ipv4_for_arp() {
+        assert_eq!(
+            client_ipv4_for_arp("192.168.1.10".parse().unwrap()),
+            Some("192.168.1.10".parse().unwrap())
+        );
+        assert_eq!(client_ipv4_for_arp("127.0.0.1".parse().unwrap()), None);
+        assert_eq!(client_ipv4_for_arp("::1".parse().unwrap()), None);
+    }
+
+    #[test]
+    fn test_parse_arp_table_mac() {
+        let table = "IP address       HW type     Flags       HW address            Mask     Device\n\
+                     192.168.1.10     0x1         0x2         aa:bb:cc:dd:ee:ff     *        eth0\n\
+                     192.168.1.11     0x1         0x2         00:00:00:00:00:00     *        eth0";
+
+        assert_eq!(
+            parse_arp_table_mac(table, "192.168.1.10".parse().unwrap()),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+        assert_eq!(
+            parse_arp_table_mac(table, "192.168.1.11".parse().unwrap()),
+            None
+        );
+        assert_eq!(
+            parse_arp_table_mac(table, "192.168.1.12".parse().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_arp_command_output_mac_unix() {
+        let output = "? (192.168.1.10) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]";
+        assert_eq!(
+            parse_arp_command_output_mac(output, "192.168.1.10".parse().unwrap()),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_arp_command_output_mac_windows() {
+        let output = "Interface: 192.168.1.1 --- 0x7\n\
+                      Internet Address      Physical Address      Type\n\
+                      192.168.1.10          aa-bb-cc-dd-ee-ff     dynamic";
+        assert_eq!(
+            parse_arp_command_output_mac(output, "192.168.1.10".parse().unwrap()),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+}

--- a/src/infra/arp.rs
+++ b/src/infra/arp.rs
@@ -195,7 +195,7 @@ mod tests {
 
         let entries = parse_arp_entries(output).collect::<Vec<_>>();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].ip, "192.168.1.10".parse().unwrap());
+        assert_eq!(entries[0].ip, "192.168.1.10".parse::<Ipv4Addr>().unwrap());
         assert_eq!(format_mac(entries[0].mac), "aa:bb:cc:dd:ee:ff");
     }
 }

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,3 +1,4 @@
+pub mod arp;
 pub mod dhcp;
 pub mod file_mode;
 pub mod http_client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ mod service;
 mod third_ext;
 #[cfg(feature = "self-update")]
 mod updater;
+mod zone;
 
 use error::Error;
 use infra::middleware;

--- a/src/zone/manager.rs
+++ b/src/zone/manager.rs
@@ -1,0 +1,32 @@
+use crate::dns::{DnsContext, DnsError, DnsRequest, DnsResponse};
+
+use super::ZoneProvider;
+
+#[derive(Default)]
+pub struct ZoneManager {
+    providers: Vec<Box<dyn ZoneProvider>>,
+}
+
+impl ZoneManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_provider<P: ZoneProvider + 'static>(mut self, provider: P) -> Self {
+        self.providers.push(Box::new(provider));
+        self
+    }
+
+    pub async fn lookup(
+        &self,
+        ctx: &DnsContext,
+        req: &DnsRequest,
+    ) -> Result<Option<DnsResponse>, DnsError> {
+        for provider in &self.providers {
+            if let Some(response) = provider.lookup(ctx, req).await? {
+                return Ok(Some(response));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -1,0 +1,7 @@
+mod manager;
+mod provider;
+mod providers;
+
+pub use manager::ZoneManager;
+pub use provider::ZoneProvider;
+pub use providers::{IdentityZoneProvider, LocalPtrZoneProvider};

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -4,4 +4,4 @@ mod providers;
 
 pub use manager::ZoneManager;
 pub use provider::ZoneProvider;
-pub use providers::{IdentityZoneProvider, LocalPtrZoneProvider};
+pub use providers::{IdentityZoneProvider, LocalPtrZoneProvider, RuleZoneProvider};

--- a/src/zone/provider.rs
+++ b/src/zone/provider.rs
@@ -1,0 +1,10 @@
+use crate::dns::{DnsContext, DnsError, DnsRequest, DnsResponse};
+
+#[async_trait::async_trait]
+pub trait ZoneProvider: Send + Sync {
+    async fn lookup(
+        &self,
+        ctx: &DnsContext,
+        req: &DnsRequest,
+    ) -> Result<Option<DnsResponse>, DnsError>;
+}

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -1,0 +1,216 @@
+use std::net::IpAddr;
+
+use crate::dns::{DnsContext, DnsError, DnsRequest, DnsResponse, RData, Record};
+use crate::infra::arp::lookup_client_mac_from_arp;
+use crate::libdns::proto::op::Query;
+use crate::libdns::proto::rr::rdata::TXT;
+use crate::libdns::proto::rr::{DNSClass, Name, RecordType};
+
+use crate::zone::ZoneProvider;
+
+const UNKNOWN_CLIENT_MAC: &str = "N/A";
+
+pub struct IdentityZoneProvider;
+
+impl IdentityZoneProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl ZoneProvider for IdentityZoneProvider {
+    async fn lookup(
+        &self,
+        ctx: &DnsContext,
+        req: &DnsRequest,
+    ) -> Result<Option<DnsResponse>, DnsError> {
+        let query = req.query().original().to_owned();
+
+        if query.query_type() != RecordType::TXT {
+            return Ok(None);
+        }
+
+        if !matches!(query.query_class(), DNSClass::CH | DNSClass::IN) {
+            return Ok(None);
+        }
+
+        let query_name = normalize_query_name(query.name());
+        let client_ip = normalize_client_ip(req.src().ip());
+        let server_name = trim_fqdn_dot(ctx.cfg().server_name().to_string());
+        let client_mac = || {
+            lookup_client_mac_from_arp(client_ip).unwrap_or_else(|| UNKNOWN_CLIENT_MAC.to_string())
+        };
+
+        let res = match query_name.as_str() {
+            // BIND compatibility
+            "hostname.bind." | "id.server." => Some(txt_response(query, server_name.clone())),
+            "version.bind." => Some(txt_response(query, crate::BUILD_VERSION.to_string())),
+            "whoami.bind." | "client.ip.bind." | "clientip.bind." => {
+                Some(txt_response(query, client_ip.to_string()))
+            }
+            "whoami.mac.bind." | "client.mac.bind." | "clientmac.bind." => {
+                Some(txt_response(query, client_mac()))
+            }
+            "smartdns.info.bind." => Some(txt_response(
+                query,
+                build_info_kv_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            "smartdns.info.json.bind." => Some(txt_response(
+                query,
+                build_info_json_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            "smartdns.bind." => Some(txt_records_response(
+                query,
+                build_info_records_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+
+            // SmartDNS native names (without `.bind`)
+            "hostname.smartdns." | "server-name.smartdns." | "hostname." => {
+                Some(txt_response(query, server_name.clone()))
+            }
+            "version.smartdns." | "server-version.smartdns." | "version." => {
+                Some(txt_response(query, crate::BUILD_VERSION.to_string()))
+            }
+            "whoami.smartdns." | "client-ip.smartdns." | "clientip.smartdns." | "whoami." => {
+                Some(txt_response(query, client_ip.to_string()))
+            }
+            "whoami-mac.smartdns." | "client-mac.smartdns." | "clientmac.smartdns." => {
+                Some(txt_response(query, client_mac()))
+            }
+            "info.smartdns." => Some(txt_response(
+                query,
+                build_info_kv_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            "json.smartdns." | "info.json.smartdns." => Some(txt_response(
+                query,
+                build_info_json_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            "smartdns." => Some(txt_records_response(
+                query,
+                build_info_records_text(
+                    &server_name,
+                    crate::BUILD_VERSION,
+                    &client_ip,
+                    &client_mac(),
+                ),
+            )),
+            _ => None,
+        };
+
+        Ok(res)
+    }
+}
+
+fn normalize_query_name(name: &Name) -> String {
+    let mut normalized = name.clone();
+    normalized.set_fqdn(true);
+    normalized.to_string().to_ascii_lowercase()
+}
+
+fn trim_fqdn_dot(name: String) -> String {
+    name.trim_end_matches('.').to_string()
+}
+
+fn normalize_client_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(addr) => addr.to_ipv4_mapped().map_or(IpAddr::V6(addr), IpAddr::V4),
+        IpAddr::V4(addr) => IpAddr::V4(addr),
+    }
+}
+
+fn txt_response(query: Query, value: String) -> DnsResponse {
+    let mut record = Record::from_rdata(
+        query.name().to_owned(),
+        crate::dns_client::MAX_TTL,
+        RData::TXT(TXT::new(vec![value])),
+    );
+    record.set_dns_class(query.query_class());
+    DnsResponse::new_with_max_ttl(query, vec![record])
+}
+
+fn txt_records_response(query: Query, values: Vec<String>) -> DnsResponse {
+    let records = values
+        .into_iter()
+        .map(|value| {
+            let mut record = Record::from_rdata(
+                query.name().to_owned(),
+                crate::dns_client::MAX_TTL,
+                RData::TXT(TXT::new(vec![value])),
+            );
+            record.set_dns_class(query.query_class());
+            record
+        })
+        .collect::<Vec<_>>();
+
+    DnsResponse::new_with_max_ttl(query, records)
+}
+
+fn build_info_kv_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> String {
+    format!(
+        "server_name={server_name};server_version={version};client_ip={client_ip};client_mac={client_mac}",
+    )
+}
+
+fn build_info_records_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> Vec<String> {
+    vec![
+        format!("server_name={server_name}"),
+        format!("server_version={version}"),
+        format!("client_ip={client_ip}"),
+        format!("client_mac={client_mac}"),
+    ]
+}
+
+fn build_info_json_text(
+    server_name: &str,
+    version: &str,
+    client_ip: &IpAddr,
+    client_mac: &str,
+) -> String {
+    let server_name = json_escape(server_name);
+    let version = json_escape(version);
+    let client_ip = json_escape(&client_ip.to_string());
+    let client_mac = json_escape(client_mac);
+    format!(
+        r#"{{"server_name":"{server_name}","server_version":"{version}","client_ip":"{client_ip}","client_mac":"{client_mac}"}}"#
+    )
+}
+
+fn json_escape(value: &str) -> String {
+    value.chars().flat_map(|c| c.escape_default()).collect()
+}

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -101,34 +101,19 @@ fn translate_query_name(name: &str) -> Option<CanonicalIdentityQuery> {
     use CanonicalIdentityQuery::*;
     Some(match name {
         // server name
-        "server-name." | "hostname.bind." | "hostname.smartdns." | "server-name.smartdns." => {
-            ServerName
-        }
+        "server-name." | "hostname.bind." => ServerName,
         // server version
-        "version." | "version.bind." | "version.smartdns." | "server-version.smartdns." => {
-            ServerVersion
-        }
+        "version." | "version.bind." => ServerVersion,
         // client ip
-        "client_ip."
-        | "client-ip."
-        | "whoami.bind."
-        | "client_ip.smartdns."
-        | "client-ip.smartdns." => ClientIp,
+        "client_ip." | "client-ip." => ClientIp,
         // client mac
-        "client_mac."
-        | "client-mac."
-        | "whoami.mac.bind."
-        | "client_mac.smartdns."
-        | "client-mac.smartdns."
-        | "whoami-mac.smartdns." => ClientMac,
+        "client_mac." | "client-mac." => ClientMac,
         // full identity
-        "whoami." | "whoami.smartdns." => WhoAmIRecords,
-        "whoami.json." | "whoami.json.smartdns." => WhoAmIJson,
+        "whoami." => WhoAmIRecords,
+        "whoami.json." => WhoAmIJson,
         // server identity
-        "smartdns." | "id.server." | "smartdns.bind." => ServerRecords,
-        "smartdns.json." | "json.smartdns." | "id.server.json." | "smartdns.info.json.bind." => {
-            ServerJson
-        }
+        "smartdns." | "id.server." => ServerRecords,
+        "smartdns.json." => ServerJson,
         _ => return None,
     })
 }
@@ -261,6 +246,9 @@ mod tests {
             translate_query_name("smartdns.json."),
             Some(CanonicalIdentityQuery::ServerJson)
         );
+        assert_eq!(translate_query_name("whoami.bind."), None);
+        assert_eq!(translate_query_name("whoami.mac.bind."), None);
+        assert_eq!(translate_query_name("whoami-mac.smartdns."), None);
         assert_eq!(translate_query_name("unknown."), None);
     }
 }

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -49,12 +49,8 @@ impl ZoneProvider for IdentityZoneProvider {
             // - BIND-compatible hostname.bind/version.bind/whoami.bind/whoami.mac.bind
             "hostname.bind." | "server-name." => Some(txt_response(query, server_name.clone())),
             "version.bind." => Some(txt_response(query, crate::BUILD_VERSION.to_string())),
-            "whoami.bind." | "client-ip." => {
-                Some(txt_response(query, client_ip.to_string()))
-            }
-            "whoami.mac.bind." | "client-mac." => {
-                Some(txt_response(query, client_mac()))
-            }
+            "whoami.bind." | "client-ip." => Some(txt_response(query, client_ip.to_string())),
+            "whoami.mac.bind." | "client-mac." => Some(txt_response(query, client_mac())),
 
             "json.smartdns." => Some(txt_response(
                 query,

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -81,16 +81,16 @@ impl ZoneProvider for IdentityZoneProvider {
             )),
 
             // SmartDNS native names (without `.bind`)
-            "hostname.smartdns." | "server-name.smartdns." | "hostname." => {
+            "hostname.smartdns." | "server-name.smartdns." | "server-name." => {
                 Some(txt_response(query, server_name.clone()))
             }
             "version.smartdns." | "server-version.smartdns." | "version." => {
                 Some(txt_response(query, crate::BUILD_VERSION.to_string()))
             }
-            "whoami.smartdns." | "client-ip.smartdns." | "clientip.smartdns." | "whoami." => {
+            "client-ip.smartdns." | "clientip.smartdns." | "client-ip." => {
                 Some(txt_response(query, client_ip.to_string()))
             }
-            "whoami-mac.smartdns." | "client-mac.smartdns." | "clientmac.smartdns." => {
+            "whoami-mac.smartdns." | "client-mac.smartdns." | "clientmac.smartdns." | "client-mac." => {
                 Some(txt_response(query, client_mac()))
             }
             "info.smartdns." => Some(txt_response(
@@ -111,7 +111,7 @@ impl ZoneProvider for IdentityZoneProvider {
                     &client_mac(),
                 ),
             )),
-            "smartdns." => Some(txt_records_response(
+            "whoami.smartdns." | "whoami." | "smartdns." => Some(txt_records_response(
                 query,
                 build_info_records_text(
                     &server_name,

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -46,12 +46,16 @@ impl ZoneProvider for IdentityZoneProvider {
             // Public stable query set:
             // - whoami: full identity records (server + client)
             // - smartdns/id.server: server identity records
-            // - server-name/version/ip.whoami/mac.whoami: single values
+            // - server-name/version/client_ip/client_mac: single values
             // - BIND-compatible hostname.bind/version.bind/whoami.bind/whoami.mac.bind
             "hostname.bind." | "server-name." => Some(txt_response(query, server_name.clone())),
             "version.bind." => Some(txt_response(query, crate::BUILD_VERSION.to_string())),
-            "whoami.bind." | "ip.whoami." => Some(txt_response(query, client_ip.to_string())),
-            "whoami.mac.bind." | "mac.whoami." => Some(txt_response(query, client_mac())),
+            "whoami.bind." | "client_ip." | "client-ip." => {
+                Some(txt_response(query, client_ip.to_string()))
+            }
+            "whoami.mac.bind." | "client_mac." | "client-mac." => {
+                Some(txt_response(query, client_mac()))
+            }
             "version." => Some(txt_response(query, crate::BUILD_VERSION.to_string())),
 
             "whoami.json." => Some(txt_response(

--- a/src/zone/providers/identity.rs
+++ b/src/zone/providers/identity.rs
@@ -90,9 +90,10 @@ impl ZoneProvider for IdentityZoneProvider {
             "client-ip.smartdns." | "clientip.smartdns." | "client-ip." => {
                 Some(txt_response(query, client_ip.to_string()))
             }
-            "whoami-mac.smartdns." | "client-mac.smartdns." | "clientmac.smartdns." | "client-mac." => {
-                Some(txt_response(query, client_mac()))
-            }
+            "whoami-mac.smartdns."
+            | "client-mac.smartdns."
+            | "clientmac.smartdns."
+            | "client-mac." => Some(txt_response(query, client_mac())),
             "info.smartdns." => Some(txt_response(
                 query,
                 build_info_kv_text(

--- a/src/zone/providers/local_ptr.rs
+++ b/src/zone/providers/local_ptr.rs
@@ -1,0 +1,86 @@
+use std::borrow::Borrow;
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use crate::dns::{DnsContext, DnsError, DnsRequest, DnsResponse, Name, RData, RecordType};
+use crate::infra::ipset::IpSet;
+use crate::libdns::proto::rr::rdata::PTR;
+use crate::zone::ZoneProvider;
+
+pub struct LocalPtrZoneProvider {
+    server_net: IpSet,
+    server_names: BTreeSet<Name>,
+}
+
+impl LocalPtrZoneProvider {
+    pub fn new() -> Self {
+        let server_net = {
+            use local_ip_address::list_afinet_netifas;
+            let ips = list_afinet_netifas().unwrap_or_default();
+            IpSet::new(ips.into_iter().map(|(_, ip)| ip.into()))
+        };
+
+        let server_names = {
+            let mut set = BTreeSet::new();
+            set.insert(Name::from_str("smartdns.").unwrap());
+            set.insert(Name::from_str("whoami.").unwrap());
+            set
+        };
+
+        Self {
+            server_net,
+            server_names,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ZoneProvider for LocalPtrZoneProvider {
+    async fn lookup(
+        &self,
+        ctx: &DnsContext,
+        req: &DnsRequest,
+    ) -> Result<Option<DnsResponse>, DnsError> {
+        if req.query().query_type() != RecordType::PTR {
+            return Ok(None);
+        }
+
+        let query = req.query();
+        let name: &Name = query.name().borrow();
+
+        let mut is_current_server = false;
+        if self.server_names.contains(name) {
+            is_current_server = true;
+        } else if let Ok(net) = name.parse_arpa_name() {
+            is_current_server = self.server_net.overlap(&net);
+
+            if !is_current_server {
+                let is_private_ip = match net.addr() {
+                    IpAddr::V4(ip) => ip.is_private(),
+                    IpAddr::V6(ip) => {
+                        const fn is_unique_local(ip: std::net::Ipv6Addr) -> bool {
+                            (ip.segments()[0] & 0xfe00) == 0xfc00
+                        }
+                        is_unique_local(ip)
+                    }
+                };
+
+                if is_private_ip {
+                    let mut res = DnsResponse::empty();
+                    res.add_query(query.original().to_owned());
+                    return Ok(Some(res));
+                }
+            }
+        }
+
+        if !is_current_server {
+            return Ok(None);
+        }
+
+        Ok(Some(DnsResponse::from_rdata(
+            query.original().to_owned(),
+            RData::PTR(PTR(ctx.cfg().server_name())),
+        )))
+    }
+}

--- a/src/zone/providers/mod.rs
+++ b/src/zone/providers/mod.rs
@@ -1,0 +1,5 @@
+mod identity;
+mod local_ptr;
+
+pub use identity::IdentityZoneProvider;
+pub use local_ptr::LocalPtrZoneProvider;

--- a/src/zone/providers/mod.rs
+++ b/src/zone/providers/mod.rs
@@ -1,5 +1,7 @@
 mod identity;
 mod local_ptr;
+mod rule;
 
 pub use identity::IdentityZoneProvider;
 pub use local_ptr::LocalPtrZoneProvider;
+pub use rule::RuleZoneProvider;

--- a/src/zone/providers/rule.rs
+++ b/src/zone/providers/rule.rs
@@ -1,0 +1,82 @@
+use crate::config::HttpsRecordRule;
+use crate::dns::*;
+use crate::middleware::Next;
+
+pub struct RuleZoneProvider;
+
+impl RuleZoneProvider {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn lookup(
+        &self,
+        ctx: &mut DnsContext,
+        req: &DnsRequest,
+        next: Next<'_, DnsContext, DnsRequest, DnsResponse, DnsError>,
+    ) -> Result<Option<DnsResponse>, DnsError> {
+        match req.query().query_type() {
+            RecordType::SRV => {
+                if let Some(srv) = ctx.domain_rule.get_ref(|r| r.srv.as_ref()) {
+                    return Ok(Some(DnsResponse::from_rdata(
+                        req.query().original().to_owned(),
+                        RData::SRV(srv.clone()),
+                    )));
+                }
+            }
+            RecordType::HTTPS => {
+                if let Some(https_rule) = ctx.domain_rule.get_ref(|r| r.https.as_ref()) {
+                    match https_rule {
+                        HttpsRecordRule::Ignore => (),
+                        HttpsRecordRule::SOA => {
+                            return Ok(Some(DnsResponse::from_rdata(
+                                req.query().original().to_owned(),
+                                RData::default_soa(),
+                            )));
+                        }
+                        HttpsRecordRule::Filter {
+                            no_ipv4_hint,
+                            no_ipv6_hint,
+                        } => {
+                            use crate::libdns::proto::rr::rdata::{SVCB, svcb::SvcParamKey};
+                            let no_ipv4_hint = *no_ipv4_hint;
+                            let no_ipv6_hint = *no_ipv6_hint;
+
+                            let mut lookup = next.run(ctx, req).await?;
+                            for record in lookup.answers_mut() {
+                                if let Some(https) = record.data_mut().as_https_mut() {
+                                    let svc_params = https
+                                        .svc_params()
+                                        .iter()
+                                        .filter(|(k, _)| match k {
+                                            SvcParamKey::Ipv4Hint => !no_ipv4_hint,
+                                            SvcParamKey::Ipv6Hint => !no_ipv6_hint,
+                                            _ => true,
+                                        })
+                                        .cloned()
+                                        .collect();
+
+                                    https.0 = SVCB::new(
+                                        https.svc_priority(),
+                                        https.target_name().clone(),
+                                        svc_params,
+                                    );
+                                }
+                            }
+                            return Ok(Some(lookup));
+                        }
+                        HttpsRecordRule::RecordData(https) => {
+                            return Ok(Some(DnsResponse::from_rdata(
+                                req.query().original().to_owned(),
+                                RData::HTTPS(https.clone()),
+                            )));
+                        }
+                    }
+                }
+            }
+            _ => (),
+        }
+
+        Ok(None)
+    }
+}


### PR DESCRIPTION
## Summary
- Canonicalize CHAOS TXT identity queries by introducing alias translation before lookup.
- Keep core handling on canonical query kinds only (single logic path).
- Keep compatibility for `hostname.bind`, `version.bind`, and `id.server`.
- Remove mismatched aliases (`whoami.bind`, `whoami.mac.bind`, `whoami-mac.smartdns`) and other unclear shadow aliases.
- Update tests and README docs to match the final supported query set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors DNS middleware query handling into a new zone/provider layer and introduces OS-specific ARP lookups (including spawning `arp` on non-Linux) for `client_mac` diagnostics.
> 
> **Overview**
> Adds a new `zone` abstraction (`ZoneManager` + `ZoneProvider`s) and rewires `DnsZoneMiddleware` to resolve built-in zones (local PTR + identity TXT) and rule-based overrides via providers before falling through to upstream resolution.
> 
> Introduces canonical `CHAOS TXT` identity queries (e.g. `whoami`, `smartdns`, `server-name`, `version`, `client_ip`, `client_mac`) with JSON and multi-record outputs, keeps compatibility for `hostname.bind`, `version.bind`, and `id.server`, and explicitly drops ambiguous aliases (tests expect SOA errors).
> 
> Implements cross-platform ARP-based MAC lookup (`/proc/net/arp` on Linux, `arp` command elsewhere) and updates README (EN/zh-CN) plus extensive new tests covering the supported query set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77fd754db51272a8e5b0a635104ee2e7b80992f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->