### PR TITLE
fix: support implicit client-rules group matching

### DIFF
--- a/src/config/parser/client_rule.rs
+++ b/src/config/parser/client_rule.rs
@@ -59,12 +59,12 @@ mod tests {
         );
 
         assert_eq!(
-            ClientRule::parse("10.10.1.0/24"),
+            ClientRule::parse("192.168.100.0/24"),
             Ok((
                 "",
                 ClientRule {
                     group: "".to_string(),
-                    client: Client::IpAddr("10.10.1.0/24".parse().unwrap())
+                    client: Client::IpAddr("192.168.100.0/24".parse().unwrap())
                 }
             ))
         );

--- a/src/config/parser/client_rule.rs
+++ b/src/config/parser/client_rule.rs
@@ -3,25 +3,16 @@ use super::*;
 impl NomParser for ClientRule {
     fn parse(input: &str) -> IResult<&str, Self> {
         let (input, client) = NomParser::parse(input)?;
-        let mut group = None;
-
-        let (input, _) = space1(input)?;
+        let mut group = String::new();
 
         let one = alt((map(
             options::parse_value(alt((tag_no_case("group"), tag("g"))), NomParser::parse),
             |v| {
-                group = Some(v);
+                group = v;
             },
         ),));
 
-        let (rest_input, _) = separated_list1(space1, one).parse(input)?;
-
-        let Some(group) = group else {
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::Tag,
-            )));
-        };
+        let (rest_input, _) = opt(preceded(space1, separated_list1(space1, one))).parse(input)?;
 
         Ok((rest_input, ClientRule { group, client }))
     }
@@ -63,6 +54,17 @@ mod tests {
                 ClientRule {
                     group: "a".to_string(),
                     client: Client::IpAddr("192.168.0.0/16".parse().unwrap())
+                }
+            ))
+        );
+
+        assert_eq!(
+            ClientRule::parse("10.10.1.0/24"),
+            Ok((
+                "",
+                ClientRule {
+                    group: "".to_string(),
+                    client: Client::IpAddr("10.10.1.0/24".parse().unwrap())
                 }
             ))
         );

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -1967,9 +1967,9 @@ mod tests {
     #[test]
     fn test_client_rule_without_group_uses_current_rule_group() {
         let cfg = RuntimeConfig::builder()
-            .with("client-rules 10.10.10.0/24")
+            .with("client-rules 192.168.1.0/24")
             .with("group-begin zerotier")
-            .with("client-rules 10.10.1.0/24")
+            .with("client-rules 192.168.100.0/24")
             .with("group-end")
             .build()
             .unwrap();
@@ -1979,7 +1979,7 @@ mod tests {
         assert_eq!(cfg.client_rules()[1].group, "zerotier");
         assert_eq!(
             cfg.client_rules()[1].client,
-            Client::IpAddr("10.10.1.0/24".parse().unwrap())
+            Client::IpAddr("192.168.100.0/24".parse().unwrap())
         );
     }
 
@@ -1987,7 +1987,7 @@ mod tests {
     fn test_client_rule_explicit_group_overrides_current_rule_group() {
         let cfg = RuntimeConfig::builder()
             .with("group-begin zerotier")
-            .with("client-rules 10.10.1.0/24 -group office")
+            .with("client-rules 192.168.100.0/24 -group office")
             .with("group-end")
             .build()
             .unwrap();

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -1968,7 +1968,7 @@ mod tests {
     fn test_client_rule_without_group_uses_current_rule_group() {
         let cfg = RuntimeConfig::builder()
             .with("client-rules 192.168.1.0/24")
-            .with("group-begin zerotier")
+            .with("group-begin group-a")
             .with("client-rules 192.168.100.0/24")
             .with("group-end")
             .build()
@@ -1976,7 +1976,7 @@ mod tests {
 
         assert_eq!(cfg.client_rules().len(), 2);
         assert_eq!(cfg.client_rules()[0].group, DEFAULT_GROUP);
-        assert_eq!(cfg.client_rules()[1].group, "zerotier");
+        assert_eq!(cfg.client_rules()[1].group, "group-a");
         assert_eq!(
             cfg.client_rules()[1].client,
             Client::IpAddr("192.168.100.0/24".parse().unwrap())
@@ -1986,7 +1986,7 @@ mod tests {
     #[test]
     fn test_client_rule_explicit_group_overrides_current_rule_group() {
         let cfg = RuntimeConfig::builder()
-            .with("group-begin zerotier")
+            .with("group-begin group-a")
             .with("client-rules 192.168.100.0/24 -group office")
             .with("group-end")
             .build()

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -1064,7 +1064,16 @@ impl RuntimeConfigBuilder {
                         group.merge(rule_group);
                     }
                 }
-                ClientRule(client_rule) => self.client_rules.push(client_rule),
+                ClientRule(mut client_rule) => {
+                    if client_rule.group.is_empty() {
+                        client_rule.group = self
+                            .rule_group_stack
+                            .last()
+                            .map(|(name, _)| name.clone())
+                            .unwrap_or_else(|| DEFAULT_GROUP.to_string());
+                    }
+                    self.client_rules.push(client_rule)
+                }
             },
             Ok((_, None)) => (),
             Err(err) => {
@@ -1953,5 +1962,37 @@ mod tests {
                 v6: None
             }
         );
+    }
+
+    #[test]
+    fn test_client_rule_without_group_uses_current_rule_group() {
+        let cfg = RuntimeConfig::builder()
+            .with("client-rules 10.10.10.0/24")
+            .with("group-begin zerotier")
+            .with("client-rules 10.10.1.0/24")
+            .with("group-end")
+            .build()
+            .unwrap();
+
+        assert_eq!(cfg.client_rules().len(), 2);
+        assert_eq!(cfg.client_rules()[0].group, DEFAULT_GROUP);
+        assert_eq!(cfg.client_rules()[1].group, "zerotier");
+        assert_eq!(
+            cfg.client_rules()[1].client,
+            Client::IpAddr("10.10.1.0/24".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_client_rule_explicit_group_overrides_current_rule_group() {
+        let cfg = RuntimeConfig::builder()
+            .with("group-begin zerotier")
+            .with("client-rules 10.10.1.0/24 -group office")
+            .with("group-end")
+            .build()
+            .unwrap();
+
+        assert_eq!(cfg.client_rules().len(), 1);
+        assert_eq!(cfg.client_rules()[0].group, "office");
     }
 }

--- a/src/dns_mw_addr.rs
+++ b/src/dns_mw_addr.rs
@@ -321,7 +321,10 @@ mod tests {
             crate::libdns::Protocol::Udp,
         );
 
-        let res_group_a = mock.search(&req_group_a, &Default::default()).await.unwrap();
+        let res_group_a = mock
+            .search(&req_group_a, &Default::default())
+            .await
+            .unwrap();
         let res_lan = mock.search(&req_lan, &Default::default()).await.unwrap();
 
         assert_eq!(

--- a/src/dns_mw_addr.rs
+++ b/src/dns_mw_addr.rs
@@ -293,7 +293,7 @@ mod tests {
     async fn test_client_rule_without_explicit_group_returns_group_address() {
         let cfg = RuntimeConfig::builder()
             .with("address /wiki.lan/192.168.1.5")
-            .with("group-begin zerotier")
+            .with("group-begin group-a")
             .with("client-rules 192.168.100.0/24")
             .with("address /wiki.lan/192.168.100.5")
             .with("group-end")
@@ -307,7 +307,7 @@ mod tests {
 
         let mut message = op::Message::query();
         message.add_query(query.clone());
-        let req_zerotier = DnsRequest::new(
+        let req_group_a = DnsRequest::new(
             message,
             "192.168.100.23:5300".parse().unwrap(),
             crate::libdns::Protocol::Udp,
@@ -321,11 +321,11 @@ mod tests {
             crate::libdns::Protocol::Udp,
         );
 
-        let res_zerotier = mock.search(&req_zerotier, &Default::default()).await.unwrap();
+        let res_group_a = mock.search(&req_group_a, &Default::default()).await.unwrap();
         let res_lan = mock.search(&req_lan, &Default::default()).await.unwrap();
 
         assert_eq!(
-            res_zerotier.records().first().unwrap().data(),
+            res_group_a.records().first().unwrap().data(),
             &RData::A("192.168.100.5".parse().unwrap())
         );
         assert_eq!(
@@ -338,7 +338,7 @@ mod tests {
     async fn test_client_rule_uses_edns_client_subnet_for_group_matching() {
         let cfg = RuntimeConfig::builder()
             .with("address /wiki.lan/192.168.1.5")
-            .with("group-begin zerotier")
+            .with("group-begin group-a")
             .with("client-rules 192.168.100.0/24")
             .with("address /wiki.lan/192.168.100.5")
             .with("group-end")

--- a/src/dns_mw_addr.rs
+++ b/src/dns_mw_addr.rs
@@ -292,10 +292,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_rule_without_explicit_group_returns_group_address() {
         let cfg = RuntimeConfig::builder()
-            .with("address /wiki.lan/10.10.10.5")
+            .with("address /wiki.lan/192.168.1.5")
             .with("group-begin zerotier")
-            .with("client-rules 10.10.1.0/24")
-            .with("address /wiki.lan/10.10.1.5")
+            .with("client-rules 192.168.100.0/24")
+            .with("address /wiki.lan/192.168.100.5")
             .with("group-end")
             .build()
             .unwrap();
@@ -309,7 +309,7 @@ mod tests {
         message.add_query(query.clone());
         let req_zerotier = DnsRequest::new(
             message,
-            "10.10.1.23:5300".parse().unwrap(),
+            "192.168.100.23:5300".parse().unwrap(),
             crate::libdns::Protocol::Udp,
         );
 
@@ -317,7 +317,7 @@ mod tests {
         message.add_query(query);
         let req_lan = DnsRequest::new(
             message,
-            "10.10.10.23:5300".parse().unwrap(),
+            "192.168.1.23:5300".parse().unwrap(),
             crate::libdns::Protocol::Udp,
         );
 
@@ -326,21 +326,21 @@ mod tests {
 
         assert_eq!(
             res_zerotier.records().first().unwrap().data(),
-            &RData::A("10.10.1.5".parse().unwrap())
+            &RData::A("192.168.100.5".parse().unwrap())
         );
         assert_eq!(
             res_lan.records().first().unwrap().data(),
-            &RData::A("10.10.10.5".parse().unwrap())
+            &RData::A("192.168.1.5".parse().unwrap())
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_client_rule_uses_edns_client_subnet_for_group_matching() {
         let cfg = RuntimeConfig::builder()
-            .with("address /wiki.lan/10.10.10.5")
+            .with("address /wiki.lan/192.168.1.5")
             .with("group-begin zerotier")
-            .with("client-rules 10.10.1.0/24")
-            .with("address /wiki.lan/10.10.1.5")
+            .with("client-rules 192.168.100.0/24")
+            .with("address /wiki.lan/192.168.100.5")
             .with("group-end")
             .build()
             .unwrap();
@@ -352,14 +352,14 @@ mod tests {
 
         let mut edns = Edns::new();
         edns.options_mut().insert(EdnsOption::Subnet(
-            ClientSubnet::from_str("10.10.1.23/32").unwrap(),
+            ClientSubnet::from_str("192.168.100.23/32").unwrap(),
         ));
         message.set_edns(edns);
 
         // ECS subnet should take precedence over the source address branch.
         let req = DnsRequest::new(
             message,
-            "10.10.10.23:5300".parse().unwrap(),
+            "192.168.1.23:5300".parse().unwrap(),
             crate::libdns::Protocol::Udp,
         );
 
@@ -367,7 +367,7 @@ mod tests {
 
         assert_eq!(
             res.records().first().unwrap().data(),
-            &RData::A("10.10.1.5".parse().unwrap())
+            &RData::A("192.168.100.5".parse().unwrap())
         );
     }
 


### PR DESCRIPTION
Fix `client-rules` matching when used inside `group-begin` blocks.

### What changed
- `client-rules` now supports omitted `-group`.
- If `-group` is omitted, it inherits current `group-begin <name>`; otherwise falls back to `default`.
- Explicit `-group` behavior is unchanged.

### Tests
Added/updated unit tests for parser, config inheritance, source-IP matching, and ECS (`EDNS Client Subnet`) matching.