### PR TITLE
domain set reload

### DIFF
--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -87,6 +87,8 @@ async fn create(
         std::fs::write(&file, format!("{config}"))?;
     }
 
+    state.app.reload().await?;
+
     Ok(StatusCode::CREATED)
 }
 
@@ -137,6 +139,7 @@ async fn delete(
     }
 
     std::fs::write(&file, format!("{config}"))?;
+    state.app.reload().await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ops::{Deref, DerefMut},
     sync::{
         Arc,
@@ -8,12 +8,12 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{RwLock, Semaphore},
+    sync::{Mutex, RwLock, Semaphore},
     task::JoinSet,
 };
 
 use crate::{
-    config::ServerOpts,
+    config::{DomainSetHttpProvider, DomainSetProvider, IDomainSetProvider, ServerOpts, WildcardName},
     dns::{DnsRequest, DnsResponse, SerialMessage},
     dns_client::DnsClient,
     dns_conf::RuntimeConfig,
@@ -45,6 +45,7 @@ impl App {
                     uptime: Instant::now(),
                     loaded_at: RwLock::const_new(Instant::now()),
                     active_queries: Default::default(),
+                    reload_lock: Mutex::new(()),
                     guard: AppGuard,
                 }
                 .into(),
@@ -61,6 +62,7 @@ impl App {
     }
 
     pub async fn reload(&self) -> anyhow::Result<()> {
+        let _reload_guard = self.reload_lock.lock().await;
         log::info!("reloading configuration...");
         let cfg = self.cfg().await;
         let cfg = cfg.reload_new()?;
@@ -89,6 +91,7 @@ impl App {
     async fn init(&self) {
         self.update_middleware_handler().await;
         self.update_listeners().await;
+        self.start_remote_domain_set_updater();
         crate::banner();
         log::info!("awaiting connections...");
         log::info!("server starting up");
@@ -180,6 +183,204 @@ impl App {
 
         *self.mw_handler.write().await = middleware_handler;
     }
+
+    fn start_remote_domain_set_updater(&self) {
+        let app = self.clone();
+        tokio::spawn(async move {
+            app.remote_domain_set_updater_loop().await;
+        });
+    }
+
+    async fn remote_domain_set_updater_loop(self) {
+        let mut states = HashMap::new();
+
+        loop {
+            let cfg = self.cfg().await;
+            sync_remote_domain_set_states(
+                &cfg.domain_set_providers,
+                cfg.remote_domain_set_snapshots(),
+                &mut states,
+                Instant::now(),
+            );
+            drop(cfg);
+
+            let changed = refresh_due_remote_domain_sets(&mut states, Instant::now()).await;
+
+            if !changed.is_empty() {
+                let changed_names = changed
+                    .iter()
+                    .map(|(key, _)| format!("{}({})", key.set_name, key.url))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                log::info!("detected remote domain-set updates, reloading: {changed_names}");
+                match self.reload().await {
+                    Ok(()) => {
+                        for (key, set) in changed {
+                            if let Some(state) = states.get_mut(&key) {
+                                state.last_domain_set = Some(set);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        log::error!(
+                            "reload configuration failed after remote domain-set update: {}",
+                            err
+                        );
+                    }
+                }
+            }
+
+            tokio::time::sleep(next_remote_domain_set_sleep_duration(
+                &states,
+                Instant::now(),
+            ))
+            .await;
+        }
+    }
+}
+
+const REMOTE_DOMAIN_SET_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+const REMOTE_DOMAIN_SET_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RemoteDomainSetKey {
+    set_name: String,
+    url: String,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteDomainSetState {
+    provider: DomainSetHttpProvider,
+    interval: Duration,
+    next_check_at: Instant,
+    last_domain_set: Option<HashSet<WildcardName>>,
+}
+
+fn sync_remote_domain_set_states(
+    providers: &HashMap<String, Vec<DomainSetProvider>>,
+    snapshots: &HashMap<String, HashMap<String, HashSet<WildcardName>>>,
+    states: &mut HashMap<RemoteDomainSetKey, RemoteDomainSetState>,
+    now: Instant,
+) {
+    use std::collections::hash_map::Entry;
+
+    let mut active_keys = HashSet::new();
+
+    for (set_name, set_providers) in providers {
+        for provider in set_providers {
+            let DomainSetProvider::Http(http_provider) = provider else {
+                continue;
+            };
+            let Some(interval) = http_provider.interval else {
+                continue;
+            };
+            if interval == 0 {
+                continue;
+            }
+
+            let key = RemoteDomainSetKey {
+                set_name: set_name.clone(),
+                url: http_provider.url.to_string(),
+            };
+            active_keys.insert(key.clone());
+            let interval = Duration::from_secs(interval as u64);
+
+            match states.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let state = entry.get_mut();
+                    if state.provider != *http_provider {
+                        state.provider = http_provider.clone();
+                        state.interval = interval;
+                        state.next_check_at = now + interval;
+                    } else if state.interval != interval {
+                        state.interval = interval;
+                        state.next_check_at = now + interval;
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let snapshot = snapshots
+                        .get(set_name)
+                        .and_then(|set| set.get(http_provider.url.as_str()))
+                        .cloned();
+                    entry.insert(RemoteDomainSetState {
+                        provider: http_provider.clone(),
+                        interval,
+                        next_check_at: now + interval,
+                        last_domain_set: snapshot,
+                    });
+                }
+            }
+        }
+    }
+
+    states.retain(|key, _| active_keys.contains(key));
+}
+
+async fn refresh_due_remote_domain_sets(
+    states: &mut HashMap<RemoteDomainSetKey, RemoteDomainSetState>,
+    now: Instant,
+) -> Vec<(RemoteDomainSetKey, HashSet<WildcardName>)> {
+    let mut due_states = Vec::new();
+
+    for (key, state) in states.iter_mut() {
+        if state.next_check_at <= now {
+            state.next_check_at = now + state.interval;
+            due_states.push((key.clone(), state.provider.clone()));
+        }
+    }
+
+    let mut changed = Vec::new();
+
+    for (key, provider) in due_states {
+        let set_name = key.set_name.clone();
+        let url = key.url.clone();
+
+        match tokio::time::timeout(REMOTE_DOMAIN_SET_FETCH_TIMEOUT, fetch_remote_domain_set(provider))
+            .await
+        {
+            Ok(Ok(next_set)) => {
+                if let Some(state) = states.get_mut(&key) {
+                    match state.last_domain_set.as_ref() {
+                        Some(last_set) if last_set != &next_set => changed.push((key, next_set)),
+                        Some(_) => (),
+                        None => changed.push((key, next_set)),
+                    }
+                }
+            }
+            Ok(Err(err)) => {
+                log::warn!(
+                    "refresh remote domain-set failed {}({}): {}",
+                    set_name,
+                    url,
+                    err
+                );
+            }
+            Err(_) => {
+                log::warn!("refresh remote domain-set timeout {}({})", set_name, url);
+            }
+        }
+    }
+
+    changed
+}
+
+async fn fetch_remote_domain_set(
+    provider: DomainSetHttpProvider,
+) -> anyhow::Result<HashSet<WildcardName>> {
+    tokio::task::spawn_blocking(move || provider.get_domain_set())
+        .await
+        .map_err(|err| anyhow::anyhow!("join remote domain-set fetch task failed: {err}"))?
+}
+
+fn next_remote_domain_set_sleep_duration(
+    states: &HashMap<RemoteDomainSetKey, RemoteDomainSetState>,
+    now: Instant,
+) -> Duration {
+    states
+        .values()
+        .map(|state| state.next_check_at.saturating_duration_since(now))
+        .min()
+        .unwrap_or(REMOTE_DOMAIN_SET_IDLE_CHECK_INTERVAL)
 }
 
 impl std::ops::Deref for App {
@@ -199,6 +400,7 @@ pub struct AppState {
     uptime: Instant,
     loaded_at: RwLock<Instant>,
     active_queries: AtomicUsize,
+    reload_lock: Mutex<()>,
     guard: AppGuard,
 }
 
@@ -552,4 +754,119 @@ fn build_middleware(
     };
 
     Arc::new(middleware_handler)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use url::Url;
+
+    use super::*;
+    use crate::config::DomainSetContentType;
+
+    fn make_http_provider(name: &str, url: &str, interval: Option<usize>) -> DomainSetProvider {
+        DomainSetProvider::Http(DomainSetHttpProvider {
+            name: name.to_string(),
+            url: Url::parse(url).unwrap(),
+            interval,
+            content_type: DomainSetContentType::List,
+        })
+    }
+
+    fn make_http_state(
+        name: &str,
+        url: &str,
+        interval: usize,
+        now: Instant,
+    ) -> RemoteDomainSetState {
+        RemoteDomainSetState {
+            provider: DomainSetHttpProvider {
+                name: name.to_string(),
+                url: Url::parse(url).unwrap(),
+                interval: Some(interval),
+                content_type: DomainSetContentType::List,
+            },
+            interval: Duration::from_secs(interval as u64),
+            next_check_at: now + Duration::from_secs(interval as u64),
+            last_domain_set: None,
+        }
+    }
+
+    #[test]
+    fn test_sync_remote_domain_set_states_seed_snapshot() {
+        let tracked_url = "https://example.com/ads.txt";
+        let ignored_url = "https://example.com/ignore.txt";
+
+        let providers = HashMap::from([(
+            "ads".to_string(),
+            vec![
+                make_http_provider("ads", tracked_url, Some(30)),
+                make_http_provider("ads", ignored_url, None),
+            ],
+        )]);
+
+        let snapshot_set = HashSet::from([WildcardName::from_str("ads.example.com").unwrap()]);
+        let snapshots = HashMap::from([(
+            "ads".to_string(),
+            HashMap::from([(tracked_url.to_string(), snapshot_set.clone())]),
+        )]);
+
+        let now = Instant::now();
+        let mut states = HashMap::new();
+
+        sync_remote_domain_set_states(&providers, &snapshots, &mut states, now);
+
+        assert_eq!(states.len(), 1);
+        let key = RemoteDomainSetKey {
+            set_name: "ads".to_string(),
+            url: tracked_url.to_string(),
+        };
+        let state = states.get(&key).unwrap();
+        assert_eq!(state.interval, Duration::from_secs(30));
+        assert_eq!(state.last_domain_set.as_ref(), Some(&snapshot_set));
+        assert!(state.next_check_at >= now + Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_sync_remote_domain_set_states_update_and_remove() {
+        let active_url = "https://example.com/active.txt";
+        let stale_url = "https://example.com/stale.txt";
+
+        let providers = HashMap::from([(
+            "block".to_string(),
+            vec![make_http_provider("block", active_url, Some(120))],
+        )]);
+
+        let snapshots = HashMap::<String, HashMap<String, HashSet<WildcardName>>>::new();
+        let now = Instant::now();
+
+        let mut states = HashMap::from([
+            (
+                RemoteDomainSetKey {
+                    set_name: "block".to_string(),
+                    url: active_url.to_string(),
+                },
+                make_http_state("block", active_url, 60, now),
+            ),
+            (
+                RemoteDomainSetKey {
+                    set_name: "block".to_string(),
+                    url: stale_url.to_string(),
+                },
+                make_http_state("block", stale_url, 60, now),
+            ),
+        ]);
+
+        sync_remote_domain_set_states(&providers, &snapshots, &mut states, now);
+
+        assert_eq!(states.len(), 1);
+        let key = RemoteDomainSetKey {
+            set_name: "block".to_string(),
+            url: active_url.to_string(),
+        };
+        let state = states.get(&key).unwrap();
+        assert_eq!(state.interval, Duration::from_secs(120));
+        assert!(state.next_check_at >= now + Duration::from_secs(120));
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use tokio::{
 
 use crate::{
     config::{
-        DomainSetHttpProvider, DomainSetProvider, IDomainSetProvider, ServerOpts, WildcardName,
+        DomainSetHttpProvider, DomainSetProvider, ServerOpts, WildcardName,
     },
     dns::{DnsRequest, DnsResponse, SerialMessage},
     dns_client::DnsClient,

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,9 @@ use tokio::{
 };
 
 use crate::{
-    config::{DomainSetHttpProvider, DomainSetProvider, IDomainSetProvider, ServerOpts, WildcardName},
+    config::{
+        DomainSetHttpProvider, DomainSetProvider, IDomainSetProvider, ServerOpts, WildcardName,
+    },
     dns::{DnsRequest, DnsResponse, SerialMessage},
     dns_client::DnsClient,
     dns_conf::RuntimeConfig,
@@ -335,8 +337,11 @@ async fn refresh_due_remote_domain_sets(
         let set_name = key.set_name.clone();
         let url = key.url.clone();
 
-        match tokio::time::timeout(REMOTE_DOMAIN_SET_FETCH_TIMEOUT, fetch_remote_domain_set(provider))
-            .await
+        match tokio::time::timeout(
+            REMOTE_DOMAIN_SET_FETCH_TIMEOUT,
+            fetch_remote_domain_set(provider),
+        )
+        .await
         {
             Ok(Ok(next_set)) => {
                 if let Some(state) = states.get_mut(&key) {

--- a/src/config/domain_set.rs
+++ b/src/config/domain_set.rs
@@ -1,5 +1,10 @@
 use enum_dispatch::enum_dispatch;
-use std::{collections::HashSet, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashSet,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use url::Url;
 
 use anyhow::Result;
@@ -33,6 +38,12 @@ pub struct DomainSetHttpProvider {
     pub url: Url,
     pub interval: Option<usize>,
     pub content_type: DomainSetContentType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DomainSetHttpLoadSource {
+    Remote,
+    Cache,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -69,6 +80,116 @@ impl IDomainSetProvider for DomainSetHttpProvider {
         read_to_domain_set(&text, &mut domain_set);
         Ok(domain_set)
     }
+}
+
+impl DomainSetHttpProvider {
+    pub(crate) fn cache_file_path(&self, set_name: &str, cache_dir: &Path) -> PathBuf {
+        cache_dir.join(make_cache_file_name(set_name, self.url.as_str()))
+    }
+
+    pub(crate) fn load_with_cache(
+        &self,
+        set_name: &str,
+        cache_dir: Option<&Path>,
+    ) -> Result<(HashSet<WildcardName>, DomainSetHttpLoadSource)> {
+        match self.get_domain_set() {
+            Ok(domain_set) => {
+                if let Some(cache_dir) = cache_dir {
+                    let cache_file = self.cache_file_path(set_name, cache_dir);
+                    if let Err(err) = write_cache_file(cache_file.as_path(), &domain_set) {
+                        crate::log::warn!(
+                            "DomainSet cache write failed {} {}: {}",
+                            set_name,
+                            self.url,
+                            err
+                        );
+                    }
+                }
+                Ok((domain_set, DomainSetHttpLoadSource::Remote))
+            }
+            Err(err) => {
+                let Some(cache_dir) = cache_dir else {
+                    return Err(err);
+                };
+
+                let cache_file = self.cache_file_path(set_name, cache_dir);
+                if !cache_file.is_file() {
+                    return Err(err);
+                }
+
+                let domain_set = read_cache_file(cache_file.as_path())?;
+                Ok((domain_set, DomainSetHttpLoadSource::Cache))
+            }
+        }
+    }
+
+    pub(crate) fn refresh_and_persist(
+        &self,
+        set_name: &str,
+        cache_file: Option<&Path>,
+    ) -> Result<HashSet<WildcardName>> {
+        let domain_set = self.get_domain_set()?;
+        if let Some(cache_file) = cache_file
+            && let Err(err) = write_cache_file(cache_file, &domain_set)
+        {
+            crate::log::warn!(
+                "DomainSet cache write failed {} {}: {}",
+                set_name,
+                self.url,
+                err
+            );
+        }
+        Ok(domain_set)
+    }
+}
+
+fn make_cache_file_name(set_name: &str, url: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    url.hash(&mut hasher);
+    let hash = hasher.finish();
+    let normalized_name = normalize_set_name(set_name);
+    format!("{normalized_name}-{hash:016x}.list")
+}
+
+fn normalize_set_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len().max(1));
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push_str("domain-set");
+    }
+    out
+}
+
+fn read_cache_file(path: &Path) -> Result<HashSet<WildcardName>> {
+    let mut domain_set = HashSet::new();
+    let text = std::fs::read_to_string(path)?;
+    read_to_domain_set(&text, &mut domain_set);
+    Ok(domain_set)
+}
+
+fn write_cache_file(path: &Path, domain_set: &HashSet<WildcardName>) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    let mut lines = domain_set
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    lines.sort_unstable();
+
+    if lines.is_empty() {
+        std::fs::write(path, "")?;
+    } else {
+        std::fs::write(path, format!("{}\n", lines.join("\n")))?;
+    }
+    Ok(())
 }
 
 fn read_to_domain_set(s: &str, domain_set: &mut HashSet<WildcardName>) {

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -737,8 +737,10 @@ impl RuntimeConfigBuilder {
         }
 
         let mut domain_sets: HashMap<String, HashSet<WildcardName>> = HashMap::new();
-        let mut remote_domain_set_snapshots: HashMap<String, HashMap<String, HashSet<WildcardName>>> =
-            HashMap::new();
+        let mut remote_domain_set_snapshots: HashMap<
+            String,
+            HashMap<String, HashSet<WildcardName>>,
+        > = HashMap::new();
 
         for (set_name, providers) in &cfg.domain_set_providers {
             let set = domain_sets.entry(set_name.to_string()).or_default();

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -39,6 +39,7 @@ pub struct RuntimeConfig {
     conf_dir: Option<PathBuf>,
     conf_file: Option<PathBuf>,
     managed_dir: Option<PathBuf>,
+    domain_set_cache_dir: Option<PathBuf>,
     inner: Config,
 
     rule_groups: HashMap<String, RuleGroup>,
@@ -641,6 +642,10 @@ impl RuntimeConfig {
         self.managed_dir.as_deref()
     }
 
+    pub(crate) fn domain_set_cache_dir(&self) -> Option<&Path> {
+        self.domain_set_cache_dir.as_deref()
+    }
+
     pub(crate) fn remote_domain_set_snapshots(
         &self,
     ) -> &HashMap<String, HashMap<String, HashSet<WildcardName>>> {
@@ -690,6 +695,8 @@ impl RuntimeConfigBuilder {
         let conf_file = self.conf_file;
         let conf_dir = self.conf_dir;
         let mut cfg = self.config;
+        let domain_set_cache_dir =
+            resolve_domain_set_cache_dir(conf_file.as_deref(), conf_dir.as_deref());
 
         if !self.rule_group_stack.is_empty() {
             while let Some((name, group)) = self.rule_group_stack.pop() {
@@ -745,20 +752,45 @@ impl RuntimeConfigBuilder {
         for (set_name, providers) in &cfg.domain_set_providers {
             let set = domain_sets.entry(set_name.to_string()).or_default();
             for p in providers.iter() {
-                match p.get_domain_set() {
-                    Ok(s) => {
-                        log::info!("DoaminSet load {} records into {}", s.len(), p.name());
-                        if let DomainSetProvider::Http(provider) = p {
-                            remote_domain_set_snapshots
-                                .entry(set_name.to_string())
-                                .or_default()
-                                .insert(provider.url.to_string(), s.clone());
+                let loaded = match p {
+                    DomainSetProvider::Http(provider) => {
+                        match provider.load_with_cache(set_name, domain_set_cache_dir.as_deref()) {
+                            Ok((s, source)) => {
+                                let source = match source {
+                                    DomainSetHttpLoadSource::Remote => "remote",
+                                    DomainSetHttpLoadSource::Cache => "cache",
+                                };
+                                log::info!(
+                                    "DoaminSet load {} records into {} ({})",
+                                    s.len(),
+                                    p.name(),
+                                    source
+                                );
+                                remote_domain_set_snapshots
+                                    .entry(set_name.to_string())
+                                    .or_default()
+                                    .insert(provider.url.to_string(), s.clone());
+                                Some(s)
+                            }
+                            Err(err) => {
+                                log::error!("DoaminSet load failed {} {}", p.name(), err);
+                                None
+                            }
                         }
-                        set.extend(s);
                     }
-                    Err(err) => {
-                        log::error!("DoaminSet load failed {} {}", p.name(), err);
-                    }
+                    _ => match p.get_domain_set() {
+                        Ok(s) => {
+                            log::info!("DoaminSet load {} records into {}", s.len(), p.name());
+                            Some(s)
+                        }
+                        Err(err) => {
+                            log::error!("DoaminSet load failed {} {}", p.name(), err);
+                            None
+                        }
+                    },
+                };
+                if let Some(s) = loaded {
+                    set.extend(s);
                 }
             }
         }
@@ -886,6 +918,7 @@ impl RuntimeConfigBuilder {
             conf_dir,
             conf_file,
             managed_dir,
+            domain_set_cache_dir,
             inner: cfg,
             rule_groups: self.rule_groups,
             domain_rule_group_map,
@@ -1181,6 +1214,16 @@ fn resolve_filepath<P: AsRef<Path>>(filepath: P, base_file: Option<&PathBuf>) ->
     }
 
     filepath.to_path_buf()
+}
+
+fn resolve_domain_set_cache_dir(
+    conf_file: Option<&Path>,
+    conf_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    conf_file
+        .and_then(Path::parent)
+        .map(|dir| dir.join("domain_sets"))
+        .or_else(|| conf_dir.map(|dir| dir.join("domain_sets")))
 }
 
 #[cfg(test)]
@@ -1891,6 +1934,68 @@ mod tests {
         assert!(!domain_set.contains(&"ads2c.cn".parse().unwrap()));
         // assert!(domain_set.is_match(&Name::from_str("ads3.net").unwrap().into()));
         // assert!(domain_set.is_match(&Name::from_str("q.ads3.net").unwrap().into()));
+    }
+
+    #[test]
+    fn test_domain_set_remote_fallback_to_cache_on_startup() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use url::Url;
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "smartdns-domain-set-cache-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let conf_file = temp_dir.join("smartdns.conf");
+        let remote_url = "http://127.0.0.1:1/block-list.txt";
+        let provider = DomainSetHttpProvider {
+            name: "block".to_string(),
+            url: Url::parse(remote_url).unwrap(),
+            interval: Some(30),
+            content_type: Default::default(),
+        };
+        let cache_file = provider.cache_file_path("block", &temp_dir.join("domain_sets"));
+        std::fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
+        std::fs::write(&cache_file, "cached.example.com\n").unwrap();
+
+        std::fs::write(
+            &conf_file,
+            format!(
+                "domain-set -name block -url {remote_url} -interval 30\n\
+                 domain-rules /domain-set:block/ --address #\n"
+            ),
+        )
+        .unwrap();
+
+        let cfg = RuntimeConfig::builder()
+            .with_conf_file(&conf_file)
+            .build()
+            .unwrap();
+
+        let rule = cfg
+            .domain_rule_group("default")
+            .find(&"cached.example.com".parse().unwrap())
+            .cloned();
+        assert_eq!(rule.get(|n| n.address.clone()), Some(AddressRuleValue::SOA));
+
+        let snapshots = cfg
+            .remote_domain_set_snapshots()
+            .get("block")
+            .and_then(|v| v.get(remote_url));
+        assert_eq!(
+            snapshots,
+            Some(&HashSet::from(["cached.example.com"
+                .parse::<WildcardName>()
+                .unwrap()]))
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
     }
 
     #[test]


### PR DESCRIPTION
Stabilize remote domain-set refresh and auto-reload to complete the periodic fetching and configuration update functionality.

The existing `domain-set -url -interval` parameters were parsed but lacked a stable background scheduler, robust change detection, and a safe reload mechanism, leading to an unstable and incomplete feature. This PR implements these missing components, including a serial lock for `App::reload()` to prevent concurrency issues, and ensures reloads only occur on actual semantic changes.

---
<p><a href="https://cursor.com/agents?id=bc-1c0f9e7d-0039-4291-a8b0-c6ea0ef05ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c0f9e7d-0039-4291-a8b0-c6ea0ef05ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

