### PR TITLE
fix(windows): ensure DNS cache is saved during system shutdown/reboot

### DIFF
--- a/src/service/windows/windows_service.rs
+++ b/src/service/windows/windows_service.rs
@@ -35,8 +35,8 @@ fn run_service(_args: Vec<OsString>) -> Result<()> {
             // control manager. Always return NoError even if not implemented.
             ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
 
-            // Handle stop
-            ServiceControl::Stop => {
+            // Handle stop and shutdown
+            ServiceControl::Stop | ServiceControl::Shutdown => {
                 unsafe {
                     if let Err(err) = windows::Win32::System::Console::GenerateConsoleCtrlEvent(
                         windows::Win32::System::Console::CTRL_C_EVENT,
@@ -62,7 +62,7 @@ fn run_service(_args: Vec<OsString>) -> Result<()> {
     status_handle.set_service_status(ServiceStatus {
         service_type: ServiceType::OWN_PROCESS,
         current_state: ServiceState::Running,
-        controls_accepted: ServiceControlAccept::STOP,
+        controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
         exit_code: ServiceExitCode::Win32(0),
         checkpoint: 0,
         wait_hint: Duration::default(),


### PR DESCRIPTION
The Windows service previously only handled SERVICE_CONTROL_STOP. By registering and handling SERVICE_CONTROL_SHUTDOWN, we ensure that the internal CTRL_C_EVENT is triggered when the system shuts down, allowing the cache middleware to persist data before the process exits.