### PR TITLE
fix(windows): prevent panic when serve-expired-ttl exceeds system uptime

### DIFF
--- a/src/dns_mw_cache.rs
+++ b/src/dns_mw_cache.rs
@@ -604,7 +604,7 @@ impl DnsCache {
         if !cache.is_empty() {
             let mut expired = vec![];
             let now = if self.expired_ttl > 0 {
-                now - Duration::from_secs(self.expired_ttl)
+                now.checked_sub(Duration::from_secs(self.expired_ttl)).unwrap_or(now)
             } else {
                 now
             } + Duration::from_secs(seconds_ahead.unwrap_or(5)); // 5 seconds ahead

--- a/src/dns_mw_cache.rs
+++ b/src/dns_mw_cache.rs
@@ -604,7 +604,8 @@ impl DnsCache {
         if !cache.is_empty() {
             let mut expired = vec![];
             let now = if self.expired_ttl > 0 {
-                now.checked_sub(Duration::from_secs(self.expired_ttl)).unwrap_or(now)
+                now.checked_sub(Duration::from_secs(self.expired_ttl))
+                    .unwrap_or(now)
             } else {
                 now
             } + Duration::from_secs(seconds_ahead.unwrap_or(5)); // 5 seconds ahead


### PR DESCRIPTION
## Problem

On Windows, `Instant` is anchored to system boot time via QueryPerformanceCounter (QPC). When `serve-expired-ttl` is configured to a value larger than the current system uptime, the subtraction in `get_expired()`:

```rust
now - Duration::from_secs(self.expired_ttl)
```

overflows, causing an unrecoverable panic:

```
thread 'tokio-runtime-worker' panicked at ...
overflow when subtracting duration from instant
```

## Reproduce

1. Set `serve-expired-ttl 259200` (3 days) in config
2. Reboot the system
3. Start SmartDNS immediately after boot (within minutes)
4. Any DNS query triggers `get_expired()` -> panic

## Root Cause

Windows QPC-based `Instant` epoch is the system boot time. `Instant::sub()` panics on underflow. The `ttl()` method in the same file correctly uses `saturating_duration_since()`, but `get_expired()` uses the bare `-` operator.

## Fix

Replace the unsafe subtraction with `checked_sub().unwrap_or(now)`. When the subtraction would overflow (expired_ttl > uptime), we use `now` as the effective cutoff, which simply means all cached entries are treated as eligible for prefetch - a safe and reasonable fallback.

**File:** `src/dns_mw_cache.rs`, method `get_expired()`

```diff
- let now = if self.expired_ttl > 0 {
-     now - Duration::from_secs(self.expired_ttl)
+ let now = if self.expired_ttl > 0 {
+     now.checked_sub(Duration::from_secs(self.expired_ttl)).unwrap_or(now)
```

## Impact

- Minimal change: single operator replacement
- No behavioral change on Linux (Instant epoch is process start or earlier, uptime >> ttl typically)
- Fixes Windows crash with zero regression risk
- Closes #687