### PR TITLE
Fix load + reload managed addresses

### DIFF
--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -68,6 +68,9 @@ impl RuntimeConfig {
 
         if let Some(conf_dir) = conf_dir.as_deref() {
             builder = builder.with_conf_dir(conf_dir);
+
+            let managed = conf_dir.join("managed");
+            builder = builder.with_managed_dir(managed);
         }
 
         let path = if let Some(ref conf) = path {
@@ -926,6 +929,11 @@ impl RuntimeConfigBuilder {
 
     pub fn with_conf_dir<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.conf_dir = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn with_managed_dir<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.managed_dir = Some(path.as_ref().to_path_buf());
         self
     }
 

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -644,6 +644,7 @@ impl RuntimeConfig {
         let builder = RuntimeConfigBuilder {
             conf_dir: self.conf_dir.clone(),
             conf_file: self.conf_file.clone(),
+            managed_dir: self.managed_dir.clone(),
             ..Self::builder()
         };
 
@@ -678,6 +679,20 @@ impl RuntimeConfigBuilder {
             if !loaded {
                 self.load_file(&conf_file)?;
             }
+        }
+
+        if let Some(managed_dir) = self.managed_dir.clone() {
+            for entry in std::fs::read_dir(managed_dir)? {
+                debug!("managed dir entry {:?}", &entry);
+                let path = entry?.path();
+                //load all .conf? or specific files only
+                if path.extension().and_then(|e| e.to_str()) == Some("conf") {
+                    info!("managed dir - try to load {:?}", &path);
+                    self.load_file(&path)?;
+                }
+            }
+        } else {
+            debug!("no managed_dir");
         }
 
         let conf_file = self.conf_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,41 @@ impl Cli {
                     })
                     .unwrap_or_default();
                 hello_starting();
+
+                // get directory from conf if empty
+                let (conf, directory) = match (conf, directory) {
+                    // conf = Some, directory = None, build diretroy from conf
+                    (Some(conf_path), None) => {
+                        match conf_path.canonicalize() {
+                            Ok(conf_abs) => {
+                                let dir = conf_abs.parent().map(|p| p.to_path_buf());
+                                (Some(conf_abs), dir)
+                            }
+                            Err(e) => {
+                                warn!("failed to canonicalize config path: {}", e);
+                                (Some(conf_path), None)
+                            }
+                        }
+                    }
+
+                    // conf = Some, directory = Some
+                    (Some(conf_path), Some(dir)) => {
+                        match conf_path.canonicalize() {
+                            Ok(conf_abs) => (Some(conf_abs), Some(dir)),
+                            Err(e) => {
+                                warn!("failed to canonicalize config path: {}", e);
+                                (Some(conf_path), Some(dir))
+                            }
+                        }
+                    }
+
+                    // conf = None
+                    (None, dir) => {
+                        warn!("no conf file specified");
+                        (None, dir) //change nothing, use as is
+                    }
+                };
+                
                 let cfg = RuntimeConfig::load(directory, conf);
 
                 cfg.summary();


### PR DESCRIPTION
I added now some functions and this now allows to load managed addresses at launch from cli, like:
`smartdns.exe -c c:\somepath\myconf.conf`

and also fixes reloading using API.

It should always load managed addresses on start, as it would be unexpected behavior if a reload would happen in between and only then the managed addresses would be loaded.

Please check if all these changes make sense and work like expected and that I did not mess up something.

For API I tried now:
-add address
-reload
-ping -> OK
-delete domain
-reload
-ping again -> fails = OK