### PR TITLE
fix: -host-name -, serve-expired-prefetch-time, DoH error visibility

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -405,15 +405,28 @@ async fn process(
                                         match e.as_soa(original) {
                                             Some(soa) => soa,
                                             None => {
-                                                log::debug!(
-                                                    "{}Response: error resolving: {}, Duration: {:?}",
+                                                // GH #307: surface upstream
+                                                // resolution failures at WARN
+                                                // with the query that failed +
+                                                // the full debug error, so
+                                                // operators can diagnose DoH /
+                                                // upstream issues without
+                                                // turning on debug logging.
+                                                log::warn!(
+                                                    "{}Response: error resolving query={} type={}: {:#}, Duration: {:?}",
                                                     if server_opts.is_background {
                                                         "Background"
                                                     } else {
                                                         ""
                                                     },
+                                                    original.name(),
+                                                    original.query_type(),
                                                     e,
                                                     start.elapsed()
+                                                );
+                                                log::debug!(
+                                                    "error detail: {:?}",
+                                                    e
                                                 );
                                                 response_header
                                                     .set_response_code(ResponseCode::ServFail);

--- a/src/app.rs
+++ b/src/app.rs
@@ -405,16 +405,26 @@ async fn process(
                                         match e.as_soa(original) {
                                             Some(soa) => soa,
                                             None => {
-                                                log::debug!(
-                                                    "{}Response: error resolving: {}, Duration: {:?}",
+                                                // GH #307: surface upstream
+                                                // resolution failures at WARN
+                                                // with the query that failed +
+                                                // the full debug error, so
+                                                // operators can diagnose DoH /
+                                                // upstream issues without
+                                                // turning on debug logging.
+                                                log::warn!(
+                                                    "{}Response: error resolving query={} type={}: {:#}, Duration: {:?}",
                                                     if server_opts.is_background {
                                                         "Background"
                                                     } else {
                                                         ""
                                                     },
+                                                    original.name(),
+                                                    original.query_type(),
                                                     e,
                                                     start.elapsed()
                                                 );
+                                                log::debug!("error detail: {:?}", e);
                                                 response_header
                                                     .set_response_code(ResponseCode::ServFail);
                                                 let mut res = DnsResponse::empty();

--- a/src/config/cache.rs
+++ b/src/config/cache.rs
@@ -57,4 +57,10 @@ pub struct CacheConfig {
 
     /// cache save interval
     pub checkpoint_time: Option<u64>,
+
+    /// Background prefetch refresh time before expiration (seconds).
+    /// When prefetch-domain is enabled, refresh active records this many
+    /// seconds before their TTL elapses. Matches the C `serve-expired-prefetch-time`
+    /// directive for config compatibility (see GH #166).
+    pub serve_expired_prefetch_time: Option<u64>,
 }

--- a/src/config/parser/mod.rs
+++ b/src/config/parser/mod.rs
@@ -142,6 +142,7 @@ pub enum ConfigItem {
     ServeExpired(bool),
     ServeExpiredTtl(u64),
     ServeExpiredReplyTtl(u64),
+    ServeExpiredPrefetchTime(u64),
     Server(NameServerInfo),
     ServerName(Name),
     ResolvFile(PathBuf),
@@ -223,6 +224,7 @@ impl std::fmt::Display for ConfigItem {
             ConfigItem::ServeExpired(_) => todo!(),
             ConfigItem::ServeExpiredTtl(_) => todo!(),
             ConfigItem::ServeExpiredReplyTtl(_) => todo!(),
+            ConfigItem::ServeExpiredPrefetchTime(_) => todo!(),
             ConfigItem::Server(c) => {
                 write!(f, "server {c}")?;
             }
@@ -405,6 +407,10 @@ fn parse_line<'a>(input: &'a str) -> IResult<&'a str, ConfigLine<'a>> {
         map(
             config("serve-expired-reply-ttl"),
             ConfigItem::ServeExpiredReplyTtl,
+        ),
+        map(
+            config("serve-expired-prefetch-time"),
+            ConfigItem::ServeExpiredPrefetchTime,
         ),
         map(config("serve-expired-ttl"), ConfigItem::ServeExpiredTtl),
         map(config("serve-expired"), ConfigItem::ServeExpired),

--- a/src/config/parser/nameserver.rs
+++ b/src/config/parser/nameserver.rs
@@ -265,6 +265,39 @@ mod tests {
         );
     }
 
+    /// GH #690: `-host-name -` should disable SNI on the TLS handshake,
+    /// matching the original C smartdns semantics. Regression guard.
+    /// Matches the exact config syntax from the user's bug report:
+    /// `server-https 2400:3200::1 -tls-host-verify dns.alidns.com
+    ///  -http-host dns.alidns.com -host-name -`
+    #[test]
+    fn test_host_name_dash_disables_sni() {
+        let (rest, ns) = NameServerInfo::parse(
+            "server-https 2400:3200::1 -tls-host-verify dns.alidns.com -http-host dns.alidns.com -host-name -",
+        )
+        .expect("parse should succeed");
+        assert_eq!(rest, "");
+        assert!(
+            ns.server.sni_off(),
+            "expected sni_off()=true when -host-name - is given, got false. \
+             URL = {}",
+            ns.server
+        );
+    }
+
+    /// Without `-host-name -`, SNI should be on by default for an https
+    /// upstream with a domain host.
+    #[test]
+    fn test_host_name_unset_keeps_sni_on() {
+        let (_rest, ns) =
+            NameServerInfo::parse("server-https https://dns.alidns.com/dns-query")
+                .expect("parse should succeed");
+        assert!(
+            !ns.server.sni_off(),
+            "expected sni_off()=false without -host-name -, got true"
+        );
+    }
+
     #[test]
     fn test_server_dhcp() {
         assert_eq!(

--- a/src/config/parser/nameserver.rs
+++ b/src/config/parser/nameserver.rs
@@ -289,9 +289,8 @@ mod tests {
     /// upstream with a domain host.
     #[test]
     fn test_host_name_unset_keeps_sni_on() {
-        let (_rest, ns) =
-            NameServerInfo::parse("server-https https://dns.alidns.com/dns-query")
-                .expect("parse should succeed");
+        let (_rest, ns) = NameServerInfo::parse("server-https https://dns.alidns.com/dns-query")
+            .expect("parse should succeed");
         assert!(
             !ns.server.sni_off(),
             "expected sni_off()=false without -host-name -, got true"

--- a/src/config/parser/options.rs
+++ b/src/config/parser/options.rs
@@ -52,11 +52,19 @@ pub fn parse_flag<
 }
 
 pub fn unkown_value(input: &str) -> IResult<&str, &str> {
+    use nom::combinator::{eof, peek};
     preceded(
         alt((tag("="), recognize(pair(opt(char(':')), space1)))),
-        recognize(pair(
-            is_not("-_ \t#"),
-            take_till(|c: char| c.is_whitespace()),
+        alt((
+            // GH #690: allow a bare `-` as a sentinel value, e.g.
+            // `-host-name -`. We accept it only when followed by whitespace
+            // or EOF, so a subsequent option like `-other` is still
+            // interpreted as a new option, not as the value of this one.
+            recognize(pair(char('-'), peek(alt((space1, eof))))),
+            recognize(pair(
+                is_not("-_ \t#"),
+                take_till(|c: char| c.is_whitespace()),
+            )),
         )),
     )
     .parse(input)
@@ -112,6 +120,26 @@ mod tests {
                 " # -exclude-default-group",
                 vec![("group", Some("bootstrap"))]
             )
+        );
+    }
+
+    /// GH #690: `-host-name -` must parse the bare `-` as the value, not as
+    /// the start of the next option.
+    #[test]
+    fn test_parse_options_dash_value() {
+        assert_eq!(
+            parse("-host-name -").unwrap(),
+            ("", vec![("host-name", Some("-"))])
+        );
+    }
+
+    /// And the dash-sentinel must not eat a subsequent option: `-a - -b`
+    /// parses as ("a", Some("-")), ("b", None).
+    #[test]
+    fn test_parse_options_dash_then_next_option() {
+        assert_eq!(
+            parse("-a - -b").unwrap(),
+            ("", vec![("a", Some("-")), ("b", None)])
         );
     }
 }

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -355,6 +355,13 @@ impl RuntimeConfig {
         self.cache.serve_expired_reply_ttl.unwrap_or(5)
     }
 
+    /// serve-expired-prefetch-time — refresh active records this many
+    /// seconds before TTL elapses. 0 disables. Matches C smartdns.
+    #[inline]
+    pub fn serve_expired_prefetch_time(&self) -> u64 {
+        self.cache.serve_expired_prefetch_time.unwrap_or(0)
+    }
+
     /// List of hosts that supply bogus NX domain results
     #[inline]
     pub fn bogus_nxdomain(&self) -> &Arc<IpSet> {
@@ -980,6 +987,7 @@ impl RuntimeConfigBuilder {
                 SpeedMode(v) => self.speed_check_mode = v,
                 ServeExpiredTtl(v) => self.cache.serve_expired_ttl = Some(v),
                 ServeExpiredReplyTtl(v) => self.cache.serve_expired_reply_ttl = Some(v),
+                ServeExpiredPrefetchTime(v) => self.cache.serve_expired_prefetch_time = Some(v),
                 CacheSize(v) => self.cache.size = Some(v),
                 ForceQtypeSoa(v) => {
                     self.force_qtype_soa.insert(v);
@@ -1746,6 +1754,25 @@ mod tests {
         assert_eq!(cfg.log.file_mode, Some(0o644u32.into()));
         cfg.config("log-file-mode 0o755");
         assert_eq!(cfg.log.file_mode, Some(0o755u32.into()));
+    }
+
+    /// GH #166: `serve-expired-prefetch-time` previously logged as
+    /// "unknown conf"; now a recognized directive.
+    #[test]
+    fn test_parse_serve_expired_prefetch_time() {
+        let cfg = RuntimeConfig::builder()
+            .with("serve-expired-prefetch-time 30")
+            .build()
+            .unwrap();
+        assert_eq!(cfg.serve_expired_prefetch_time(), 30);
+        assert_eq!(cfg.cache.serve_expired_prefetch_time, Some(30));
+    }
+
+    #[test]
+    fn test_serve_expired_prefetch_time_default() {
+        let cfg = RuntimeConfig::builder().build().unwrap();
+        // Default is 0 (disabled).
+        assert_eq!(cfg.serve_expired_prefetch_time(), 0);
     }
 
     #[test]

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -355,6 +355,13 @@ impl RuntimeConfig {
         self.cache.serve_expired_reply_ttl.unwrap_or(5)
     }
 
+    /// serve-expired-prefetch-time — refresh active records this many
+    /// seconds before TTL elapses. 0 disables. Matches C smartdns.
+    #[inline]
+    pub fn serve_expired_prefetch_time(&self) -> u64 {
+        self.cache.serve_expired_prefetch_time.unwrap_or(0)
+    }
+
     /// List of hosts that supply bogus NX domain results
     #[inline]
     pub fn bogus_nxdomain(&self) -> &Arc<IpSet> {
@@ -980,6 +987,7 @@ impl RuntimeConfigBuilder {
                 SpeedMode(v) => self.speed_check_mode = v,
                 ServeExpiredTtl(v) => self.cache.serve_expired_ttl = Some(v),
                 ServeExpiredReplyTtl(v) => self.cache.serve_expired_reply_ttl = Some(v),
+                ServeExpiredPrefetchTime(v) => self.cache.serve_expired_prefetch_time = Some(v),
                 CacheSize(v) => self.cache.size = Some(v),
                 ForceQtypeSoa(v) => {
                     self.force_qtype_soa.insert(v);
@@ -1744,6 +1752,25 @@ mod tests {
         assert_eq!(cfg.log.file_mode, Some(0o644u32.into()));
         cfg.config("log-file-mode 0o755");
         assert_eq!(cfg.log.file_mode, Some(0o755u32.into()));
+    }
+
+    /// GH #166: `serve-expired-prefetch-time` previously logged as
+    /// "unknown conf"; now a recognized directive.
+    #[test]
+    fn test_parse_serve_expired_prefetch_time() {
+        let cfg = RuntimeConfig::builder()
+            .with("serve-expired-prefetch-time 30")
+            .build()
+            .unwrap();
+        assert_eq!(cfg.serve_expired_prefetch_time(), 30);
+        assert_eq!(cfg.cache.serve_expired_prefetch_time, Some(30));
+    }
+
+    #[test]
+    fn test_serve_expired_prefetch_time_default() {
+        let cfg = RuntimeConfig::builder().build().unwrap();
+        // Default is 0 (disabled).
+        assert_eq!(cfg.serve_expired_prefetch_time(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Three small, independently-cherry-pickable fixes for open issues. No new
dependencies, no feature flags, behavior-preserving except where the bug
fix changes incorrect behavior.

## fix(parser): \`-host-name -\` now correctly disables SNI (#690)

When \`-host-name -\` is given, smartdns-rs was still sending SNI in the
TLS handshake, contrary to the original C smartdns behavior.

**Root cause** was in the option-value parser
\`src/config/parser/options.rs::unkown_value()\`, which explicitly
rejects any value starting with \`-\` via \`is_not(\"-_ \\t#\")\`.
So \`-host-name -\` parsed as \`(\"host-name\", None)\` instead of
\`(\"host-name\", Some(\"-\"))\`, and the downstream code in
\`parser/nameserver.rs\` (which already handles \`\"-\"\` correctly)
was never reached.

**Fix**: add an \`alt\` branch in \`unkown_value\` that accepts a single
bare \`-\` value, but only when followed by whitespace or EOF. This
preserves the existing semantics — \`-foo -bar\` still parses \`-bar\`
as the next option, not as the value of \`-foo\`.

**Regression tests** added in both the options parser and the
nameserver parser, including the exact config from the bug report.

Closes #690.

## feat(config): recognize \`serve-expired-prefetch-time\` directive (#166)

The C smartdns directive \`serve-expired-prefetch-time [seconds]\` was
not parsed in -rs and showed up as \`WARN: unknown conf: ...\` on
startup, blocking users from sharing a single config across both
implementations.

Adds:
- \`CacheConfig::serve_expired_prefetch_time: Option<u64>\`
- \`ConfigItem::ServeExpiredPrefetchTime(u64)\` variant + parser entry,
  placed before \`serve-expired-ttl\` / \`serve-expired\` so the longer
  key wins the \`alt\` race
- \`RuntimeConfig::serve_expired_prefetch_time()\` accessor (default
  \`0\` = disabled, matching C semantics)

Note: this PR only makes the directive a recognized config key. Wiring
it into actual prefetch behavior in the cache middleware is left as a
separate follow-up — the user-visible benefit here is just getting rid
of the \"unknown conf\" warning.

Refs #166.

## fix(app): elevate upstream resolver errors to WARN with query context (#307)

Upstream resolution failures (DoH timeouts, TLS handshake errors,
refused connections) were logged at \`debug!\` with just the error and
elapsed time — invisible at default log levels, and missing the query
name + type that would let an operator pinpoint which lookup failed.

Now:
- \`warn!\` with query name, type, formatted error chain (\`{:#}\`), and
  elapsed time. Visible at the default log level.
- Follow-up \`debug!\` line carries the full \`{:?}\` form for deeper
  diagnosis when debug logging is on.

Only the SERVFAIL path is affected. NXDomain and SOA-from-upstream
paths are unchanged — those are expected outcomes, not errors.

Closes #307.

## Verified

- \`cargo build\` ✅
- \`cargo test -- --skip dns_client --skip infra::ping\` → 239 / 239 pass
  (skipped tests are network-dependent and unrelated)
- \`cargo clippy --all-targets\` → no new warnings in introduced code
- 6 new regression tests covering:
  - options dash-sentinel value parsing (both with and without a
    trailing option)
  - \`server-https ... -host-name -\` produces \`sni_off()=true\`
  - default \`server-https ...\` keeps \`sni_off()=false\`
  - \`serve-expired-prefetch-time 30\` round-trips
  - default \`serve_expired_prefetch_time()\` returns \`0\`

## Test plan

- [ ] Confirm \`-host-name -\` no longer sends SNI (verifiable via
      Wireshark on the ClientHello).
- [ ] Confirm an existing config with \`serve-expired-prefetch-time N\`
      no longer logs \"unknown conf\".
- [ ] Confirm DoH failures show \`WARN ... error resolving query=... type=...\`
      at default log level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)