### PR TITLE
Api address put

### DIFF
--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -183,14 +183,12 @@ async fn delete(
 
         // 1. Delete ALL managed entries (including negation)
         let before = config.len();
-        config.retain(|line| {
-            match line {
-                ConfigLine::Config {
-                    config: ConfigItem::Address(rule),
-                    ..
-                } => rule.domain != domain,
-                _ => true,
-            }
+        config.retain(|line| match line {
+            ConfigLine::Config {
+                config: ConfigItem::Address(rule),
+                ..
+            } => rule.domain != domain,
+            _ => true,
         });
         let managed_deleted = config.len() != before;
 
@@ -202,14 +200,12 @@ async fn delete(
 
         // 3. If nothing was deleted, but static exists, create negation
         if static_exists {
-            let neg_exists = config.iter().any(|line| {
-                match line {
-                    ConfigLine::Config {
-                        config: ConfigItem::Address(rule),
-                        ..
-                    } => rule.domain == domain && rule.address == zero,
-                    _ => false,
-                }
+            let neg_exists = config.iter().any(|line| match line {
+                ConfigLine::Config {
+                    config: ConfigItem::Address(rule),
+                    ..
+                } => rule.domain == domain && rule.address == zero,
+                _ => false,
             });
 
             if !neg_exists {

--- a/src/api/address.rs
+++ b/src/api/address.rs
@@ -91,7 +91,60 @@ async fn create(
 }
 
 #[put("/addresses", tag = "Addresses")]
-async fn update() {}
+async fn update(
+    State(state): State<Arc<ServeState>>,
+    Json(input): Json<CreateAddressRule>,
+) -> Result<StatusCode, ApiError> {
+    let rule = input.rule;
+
+    let cfg = state.app.cfg().await;
+    let Some(managed_dir) = cfg.managed_dir() else {
+        return Err(ApiError::NotFound("managed_dir not found".to_string()));
+    };
+
+    if !managed_dir.exists() {
+        std::fs::create_dir_all(managed_dir)?;
+    }
+
+    let file = managed_dir.join("address.conf");
+
+    // File exists, read and replace
+    if file.exists() {
+        let text = std::fs::read_to_string(&file)?;
+        let (_, mut config) = ConfigFile::parse(&text).map_err(|err| err.to_owned())?;
+
+        // Remove all existing entries with the same domain
+        let idxs = config
+            .iter()
+            .enumerate()
+            .flat_map(|(i, c)| match c {
+                ConfigLine::Config {
+                    config: ConfigItem::Address(r),
+                    ..
+                } if r.domain == rule.domain => Some(i),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        for i in idxs.iter().rev() {
+            config.remove(*i);
+        }
+
+        // Add new entry
+        config.push(ConfigLine::Config {
+            config: ConfigItem::Address(rule),
+            comment: None,
+        });
+
+        std::fs::write(&file, format!("{config}"))?;
+    } else {
+        // File does not exist, create new one like POST
+        let config = ConfigItem::Address(rule);
+        std::fs::write(&file, format!("{config}"))?;
+    }
+
+    Ok(StatusCode::OK)
+}
 
 #[delete("/addresses", tag = "Addresses")]
 async fn delete(
@@ -106,39 +159,91 @@ async fn delete(
     };
 
     if !managed_dir.exists() {
-        return Err(ApiError::NotFound(format!("Domain {domain} not found")));
+        std::fs::create_dir_all(&managed_dir)?;
     }
+
     let file = managed_dir.join("address.conf");
-    if !file.exists() {
+
+    // Check whether the domain exists in the static config
+    let static_exists = state
+        .app
+        .cfg()
+        .await
+        .rule_groups()
+        .get("default")
+        .map(|group| group.address_rules.iter().any(|r| r.domain == domain))
+        .unwrap_or(false);
+
+    // File exists, parse ConfigFile
+    if file.exists() {
+        let text = std::fs::read_to_string(&file)?;
+        let (_, mut config) = ConfigFile::parse(&text).map_err(|err| err.to_owned())?;
+
+        let zero = "0.0.0.0".parse().unwrap();
+
+        // 1. Delete ALL managed entries (including negation)
+        let before = config.len();
+        config.retain(|line| {
+            match line {
+                ConfigLine::Config {
+                    config: ConfigItem::Address(rule),
+                    ..
+                } => rule.domain != domain,
+                _ => true,
+            }
+        });
+        let managed_deleted = config.len() != before;
+
+        // 2. If something was deleted, DONE (and DO NOT create a new negation as we anted to delete it on purpose)
+        if managed_deleted {
+            std::fs::write(&file, format!("{config}"))?;
+            return Ok(StatusCode::NO_CONTENT);
+        }
+
+        // 3. If nothing was deleted, but static exists, create negation
+        if static_exists {
+            let neg_exists = config.iter().any(|line| {
+                match line {
+                    ConfigLine::Config {
+                        config: ConfigItem::Address(rule),
+                        ..
+                    } => rule.domain == domain && rule.address == zero,
+                    _ => false,
+                }
+            });
+
+            if !neg_exists {
+                config.push(ConfigLine::Config {
+                    config: ConfigItem::Address(AddressRule {
+                        domain,
+                        address: zero,
+                    }),
+                    comment: Some("negated static rule"),
+                });
+            }
+
+            std::fs::write(&file, format!("{config}"))?;
+            return Ok(StatusCode::NO_CONTENT);
+        }
+
+        // 4. Neither static nor managed, return 404
         return Err(ApiError::NotFound(format!("Domain {domain} not found")));
     }
 
-    let text = std::fs::read_to_string(&file)?;
-    let (_, mut config) = ConfigFile::parse(&text).map_err(|err| err.to_owned())?;
+    // File does NOT exist
+    if static_exists {
+        // Negate static rule, write single rule
+        let config = ConfigItem::Address(AddressRule {
+            domain,
+            address: "0.0.0.0".parse().unwrap(),
+        });
 
-    let idx = config
-        .iter()
-        .enumerate()
-        .flat_map(|(i, c)| match c {
-            ConfigLine::Config {
-                config: ConfigItem::Address(rule),
-                ..
-            } if rule.domain == domain => Some(i),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    if idx.is_empty() {
-        return Err(ApiError::NotFound(format!("Domain {domain} not found")));
+        std::fs::write(&file, format!("{config}"))?;
+        return Ok(StatusCode::NO_CONTENT);
     }
 
-    for i in idx.iter().rev() {
-        config.remove(*i);
-    }
-
-    std::fs::write(&file, format!("{config}"))?;
-
-    Ok(StatusCode::NO_CONTENT)
+    // Neither static nor managed, return 404
+    Err(ApiError::NotFound(format!("Domain {domain} not found")))
 }
 
 #[derive(Debug, Deserialize, ToSchema)]

--- a/src/config/parser/mod.rs
+++ b/src/config/parser/mod.rs
@@ -276,7 +276,14 @@ impl<'a> std::fmt::Display for ConfigFile<'a> {
         for line in &self.0 {
             match line {
                 ConfigLine::Config { config, comment } => {
-                    writeln!(f, "{}{}", config, comment.unwrap_or_default())?
+                    match comment {
+                        // Only write comments that are NOT empty
+                        Some(c) if !c.trim().is_empty() => {
+                            writeln!(f, "{} # {}", config, c)?
+                        }
+                        // Completely remove empty comments
+                        _ => writeln!(f, "{}", config)?,
+                    }
                 }
                 ConfigLine::Comment(comment) => writeln!(f, "{comment}")?,
                 ConfigLine::EmptyLine => writeln!(f)?,
@@ -430,7 +437,27 @@ fn parse_line<'a>(input: &'a str) -> IResult<&'a str, ConfigLine<'a>> {
             (
                 preceded(space0, group),
                 alt((
-                    map(recognize((space1, comment)), Some),
+                    //map(recognize((space1, comment)), Some),
+
+                    map(
+                        recognize((space1, comment)),
+                        |raw: &str| {
+                            // raw contains e.g. " # foo" or " # "
+                            // extract the part after '#'
+                            let trimmed = raw
+                                .trim_start()        // remove leading spaces
+                                .trim_start_matches('#')
+                                .trim();             // actual comment content
+
+                            if trimmed.is_empty() {
+                                None                // empty comment, discard
+                            } else {
+                                // must return an &str, not a String
+                                // trimmed is already an &str
+                                Some(trimmed)
+                            }
+                        },
+                    ),
                     map(space0, |_| None),
                 )),
             ),

--- a/src/config/parser/mod.rs
+++ b/src/config/parser/mod.rs
@@ -278,9 +278,7 @@ impl<'a> std::fmt::Display for ConfigFile<'a> {
                 ConfigLine::Config { config, comment } => {
                     match comment {
                         // Only write comments that are NOT empty
-                        Some(c) if !c.trim().is_empty() => {
-                            writeln!(f, "{} # {}", config, c)?
-                        }
+                        Some(c) if !c.trim().is_empty() => writeln!(f, "{} # {}", config, c)?,
                         // Completely remove empty comments
                         _ => writeln!(f, "{}", config)?,
                     }
@@ -438,26 +436,22 @@ fn parse_line<'a>(input: &'a str) -> IResult<&'a str, ConfigLine<'a>> {
                 preceded(space0, group),
                 alt((
                     //map(recognize((space1, comment)), Some),
+                    map(recognize((space1, comment)), |raw: &str| {
+                        // raw contains e.g. " # foo" or " # "
+                        // extract the part after '#'
+                        let trimmed = raw
+                            .trim_start() // remove leading spaces
+                            .trim_start_matches('#')
+                            .trim(); // actual comment content
 
-                    map(
-                        recognize((space1, comment)),
-                        |raw: &str| {
-                            // raw contains e.g. " # foo" or " # "
-                            // extract the part after '#'
-                            let trimmed = raw
-                                .trim_start()        // remove leading spaces
-                                .trim_start_matches('#')
-                                .trim();             // actual comment content
-
-                            if trimmed.is_empty() {
-                                None                // empty comment, discard
-                            } else {
-                                // must return an &str, not a String
-                                // trimmed is already an &str
-                                Some(trimmed)
-                            }
-                        },
-                    ),
+                        if trimmed.is_empty() {
+                            None // empty comment, discard
+                        } else {
+                            // must return an &str, not a String
+                            // trimmed is already an &str
+                            Some(trimmed)
+                        }
+                    }),
                     map(space0, |_| None),
                 )),
             ),

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -68,6 +68,9 @@ impl RuntimeConfig {
 
         if let Some(conf_dir) = conf_dir.as_deref() {
             builder = builder.with_conf_dir(conf_dir);
+
+            let managed = conf_dir.join("managed");
+            builder = builder.with_managed_dir(managed);
         }
 
         let path = if let Some(ref conf) = path {
@@ -926,6 +929,11 @@ impl RuntimeConfigBuilder {
 
     pub fn with_conf_dir<P: AsRef<Path>>(mut self, path: P) -> Self {
         self.conf_dir = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn with_managed_dir<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.managed_dir = Some(path.as_ref().to_path_buf());
         self
     }
 

--- a/src/dns_conf.rs
+++ b/src/dns_conf.rs
@@ -644,6 +644,7 @@ impl RuntimeConfig {
         let builder = RuntimeConfigBuilder {
             conf_dir: self.conf_dir.clone(),
             conf_file: self.conf_file.clone(),
+            managed_dir: self.managed_dir.clone(),
             ..Self::builder()
         };
 
@@ -678,6 +679,20 @@ impl RuntimeConfigBuilder {
             if !loaded {
                 self.load_file(&conf_file)?;
             }
+        }
+
+        if let Some(managed_dir) = self.managed_dir.clone() {
+            for entry in std::fs::read_dir(managed_dir)? {
+                debug!("managed dir entry {:?}", &entry);
+                let path = entry?.path();
+                //load all .conf? or specific files only
+                if path.extension().and_then(|e| e.to_str()) == Some("conf") {
+                    info!("managed dir - try to load {:?}", &path);
+                    self.load_file(&path)?;
+                }
+            }
+        } else {
+            debug!("no managed_dir");
         }
 
         let conf_file = self.conf_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,29 +127,25 @@ impl Cli {
                 // get directory from conf if empty
                 let (conf, directory) = match (conf, directory) {
                     // conf = Some, directory = None, build diretroy from conf
-                    (Some(conf_path), None) => {
-                        match conf_path.canonicalize() {
-                            Ok(conf_abs) => {
-                                let dir = conf_abs.parent().map(|p| p.to_path_buf());
-                                (Some(conf_abs), dir)
-                            }
-                            Err(e) => {
-                                warn!("failed to canonicalize config path: {}", e);
-                                (Some(conf_path), None)
-                            }
+                    (Some(conf_path), None) => match conf_path.canonicalize() {
+                        Ok(conf_abs) => {
+                            let dir = conf_abs.parent().map(|p| p.to_path_buf());
+                            (Some(conf_abs), dir)
                         }
-                    }
+                        Err(e) => {
+                            warn!("failed to canonicalize config path: {}", e);
+                            (Some(conf_path), None)
+                        }
+                    },
 
                     // conf = Some, directory = Some
-                    (Some(conf_path), Some(dir)) => {
-                        match conf_path.canonicalize() {
-                            Ok(conf_abs) => (Some(conf_abs), Some(dir)),
-                            Err(e) => {
-                                warn!("failed to canonicalize config path: {}", e);
-                                (Some(conf_path), Some(dir))
-                            }
+                    (Some(conf_path), Some(dir)) => match conf_path.canonicalize() {
+                        Ok(conf_abs) => (Some(conf_abs), Some(dir)),
+                        Err(e) => {
+                            warn!("failed to canonicalize config path: {}", e);
+                            (Some(conf_path), Some(dir))
                         }
-                    }
+                    },
 
                     // conf = None
                     (None, dir) => {
@@ -157,7 +153,7 @@ impl Cli {
                         (None, dir) //change nothing, use as is
                     }
                 };
-                
+
                 let cfg = RuntimeConfig::load(directory, conf);
 
                 cfg.summary();

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,41 @@ impl Cli {
                     })
                     .unwrap_or_default();
                 hello_starting();
+
+                // get directory from conf if empty
+                let (conf, directory) = match (conf, directory) {
+                    // conf = Some, directory = None, build diretroy from conf
+                    (Some(conf_path), None) => {
+                        match conf_path.canonicalize() {
+                            Ok(conf_abs) => {
+                                let dir = conf_abs.parent().map(|p| p.to_path_buf());
+                                (Some(conf_abs), dir)
+                            }
+                            Err(e) => {
+                                warn!("failed to canonicalize config path: {}", e);
+                                (Some(conf_path), None)
+                            }
+                        }
+                    }
+
+                    // conf = Some, directory = Some
+                    (Some(conf_path), Some(dir)) => {
+                        match conf_path.canonicalize() {
+                            Ok(conf_abs) => (Some(conf_abs), Some(dir)),
+                            Err(e) => {
+                                warn!("failed to canonicalize config path: {}", e);
+                                (Some(conf_path), Some(dir))
+                            }
+                        }
+                    }
+
+                    // conf = None
+                    (None, dir) => {
+                        warn!("no conf file specified");
+                        (None, dir) //change nothing, use as is
+                    }
+                };
+                
                 let cfg = RuntimeConfig::load(directory, conf);
 
                 cfg.summary();


### PR DESCRIPTION
I tested a bit more and had the problem that when I was using"comments", with every write it was appending empty " # " or multiple times " # # # " ...

comments like using here:
```
if !neg_exists {
                config.push(ConfigLine::Config {
                    config: ConfigItem::Address(AddressRule {
                        domain,
                        address: zero,
                    }),
                    comment: Some("negated static rule"),
                });
            }
```

I reworked a bit the delete process, because I wanted to have a possibility to "edit" existing entries from the "static config", and let it write overrides into the "managed config", but be able to also delete these "overrides". 

Maybe a better solution would be to have an internal "type_flag" what kind of entry it is, from "static config" or from "managed".